### PR TITLE
hotfix/S4-60 - Signatory Info Error Links

### DIFF
--- a/services/infrastructure/mongo.initdb.js
+++ b/services/infrastructure/mongo.initdb.js
@@ -1,5 +1,5 @@
 /*
- * account 
+ * account
  */
 db.api_clients.insert({
   "_id" : "1234567890.apps.ch.gov.uk",
@@ -41,7 +41,7 @@ db.users.insert({
 })
 
 /*
- * company_profile 
+ * company_profile
  */
 db = db.getSiblingDB('company_profile')
 
@@ -162,7 +162,7 @@ db.company_profile.insert({
 })
 
 /*
- * appointments 
+ * appointments
  */
 db = db.getSiblingDB('appointments')
 
@@ -221,8 +221,8 @@ db.appointments.insert({
       "updated_at": 1432503011000,
       "links": {
          "officer": {
-            "appointments": "/officers/activeOfficer1/appointments",
-            "self": "/officers/activeOfficer1"
+            "appointments": "/officers/W1V267fKJfc6USCGEA6i9YEm6KI/appointments",
+            "self": "/officers/W1V267fKJfc6USCGEA6i9YEm6KI"
          },
          "self": "/company/01777777/appointments/app2"
       },
@@ -246,7 +246,7 @@ db.appointments.insert({
       }
    },
    "appointment_id": "app2",
-   "officer_id": "activeOfficer1",
+   "officer_id": "W1V267fKJfc6USCGEA6i9YEm6KI",
    "updated": {
       "at": 1433406704142
    },
@@ -267,8 +267,8 @@ db.appointments.insert({
       "updated_at": 1432503011000,
       "links": {
          "officer": {
-            "appointments": "/officers/activeOfficer2/appointments",
-            "self": "/officers/activeOfficer2"
+            "appointments": "/officers/W1V267fKJfc6USCGEA6i9YEm6KK/appointments",
+            "self": "/officers/W1V267fKJfc6USCGEA6i9YEm6KK"
          },
          "self": "/company/01777777/appointments/app3"
       },
@@ -293,7 +293,7 @@ db.appointments.insert({
       }
    },
    "appointment_id": "app3",
-   "officer_id": "activeOfficer2",
+   "officer_id": "W1V267fKJfc6USCGEA6i9YEm6KK",
    "updated": {
       "at": 1433406704142
    },
@@ -355,7 +355,7 @@ db.appointments.insert({
 })
 
 /*
- * company_metrics 
+ * company_metrics
  */
 db = db.getSiblingDB('company_metrics')
 

--- a/src/schemas/defineSignatoryInfo.schema.ts
+++ b/src/schemas/defineSignatoryInfo.schema.ts
@@ -15,29 +15,32 @@ function generateSchemaForSignatories(signatories: DirectorToSign[]): Joi.Schema
 }
 
 function generateSchemaForSignatory(signatory: DirectorToSign): Joi.SchemaMap {
-  const isSigningKey: string = `isSigning_${signatory.id}`
+  const signatoryId: string = formatSignatoryId(signatory)
+  const signatoryName: string = signatory.name
+
+  const isSigningKey: string = `isSigning_${signatoryId}`
 
   return {
-    [isSigningKey]: generateIsSigningRadioSchema(signatory),
-    [`directorEmail_${signatory.id}`]: generateDirectorEmailSchema(isSigningKey, signatory),
-    [`onBehalfName_${signatory.id}`]: generateOnBehalfNameSchema(isSigningKey, signatory),
-    [`onBehalfEmail_${signatory.id}`]: generateOnBehalfEmailSchema(isSigningKey, signatory)
+    [isSigningKey]: generateIsSigningRadioSchema(signatoryName),
+    [`directorEmail_${signatoryId}`]: generateDirectorEmailSchema(isSigningKey, signatoryName),
+    [`onBehalfName_${signatoryId}`]: generateOnBehalfNameSchema(isSigningKey, signatoryName),
+    [`onBehalfEmail_${signatoryId}`]: generateOnBehalfEmailSchema(isSigningKey, signatoryName)
   }
 }
 
-function generateIsSigningRadioSchema(signatory: DirectorToSign): Joi.StringSchema {
+function generateIsSigningRadioSchema(signatoryName: string): Joi.StringSchema {
   return Joi
     .string()
     .required()
     .valid(SignatorySigning.WILL_SIGN, SignatorySigning.ON_BEHALF)
     .messages({
-      'any.only': `Select how ${signatory.name} will be signing the application`,
-      'any.required': `Select how ${signatory.name} will be signing the application`,
-      'string.empty': `Select how ${signatory.name} will be signing the application`
+      'any.only': `Select how ${signatoryName} will be signing the application`,
+      'any.required': `Select how ${signatoryName} will be signing the application`,
+      'string.empty': `Select how ${signatoryName} will be signing the application`
     })
 }
 
-function generateDirectorEmailSchema(isSigningKey: string, signatory: DirectorToSign): Joi.AlternativesSchema {
+function generateDirectorEmailSchema(isSigningKey: string, signatoryName: string): Joi.AlternativesSchema {
   return Joi
     .when(isSigningKey, {
       is: SignatorySigning.WILL_SIGN,
@@ -46,14 +49,14 @@ function generateDirectorEmailSchema(isSigningKey: string, signatory: DirectorTo
         .required()
         .email()
         .messages({
-          'any.required': `Enter the email address for ${signatory.name}`,
-          'string.empty': `Enter the email address for ${signatory.name}`,
-          'string.email': `Enter a valid email address for ${signatory.name}`
+          'any.required': `Enter the email address for ${signatoryName}`,
+          'string.empty': `Enter the email address for ${signatoryName}`,
+          'string.email': `Enter a valid email address for ${signatoryName}`
         })
     })
 }
 
-function generateOnBehalfNameSchema(isSigningKey: string, signatory: DirectorToSign): Joi.AlternativesSchema {
+function generateOnBehalfNameSchema(isSigningKey: string, signatoryName: string): Joi.AlternativesSchema {
   return Joi
     .when(isSigningKey, {
       is: SignatorySigning.ON_BEHALF,
@@ -62,14 +65,14 @@ function generateOnBehalfNameSchema(isSigningKey: string, signatory: DirectorToS
         .required()
         .max(250)
         .messages({
-          'any.required': `Enter the name for the person signing on behalf of ${signatory.name}`,
-          'string.empty': `Enter the name for the person signing on behalf of ${signatory.name}`,
-          'string.max': `Enter a name that is less than 250 characters for the person signing on behalf of ${signatory.name}`
+          'any.required': `Enter the name for the person signing on behalf of ${signatoryName}`,
+          'string.empty': `Enter the name for the person signing on behalf of ${signatoryName}`,
+          'string.max': `Enter a name that is less than 250 characters for the person signing on behalf of ${signatoryName}`
         })
     })
 }
 
-function generateOnBehalfEmailSchema(isSigningKey: string, signatory: DirectorToSign): Joi.AlternativesSchema {
+function generateOnBehalfEmailSchema(isSigningKey: string, signatoryName: string): Joi.AlternativesSchema {
   return Joi
     .when(isSigningKey, {
       is: SignatorySigning.ON_BEHALF,
@@ -78,9 +81,13 @@ function generateOnBehalfEmailSchema(isSigningKey: string, signatory: DirectorTo
         .required()
         .email()
         .messages({
-          'any.required': `Enter the email address for the person signing on behalf of ${signatory.name}`,
-          'string.empty': `Enter the email address for the person signing on behalf of ${signatory.name}`,
-          'string.email': `Enter a valid email address for the person signing on behalf of ${signatory.name}`
+          'any.required': `Enter the email address for the person signing on behalf of ${signatoryName}`,
+          'string.empty': `Enter the email address for the person signing on behalf of ${signatoryName}`,
+          'string.email': `Enter a valid email address for the person signing on behalf of ${signatoryName}`
         })
     })
+}
+
+function formatSignatoryId(signatory: DirectorToSign): string {
+  return signatory.id.toLowerCase()
 }

--- a/src/services/signatories/signatory.service.ts
+++ b/src/services/signatories/signatory.service.ts
@@ -32,12 +32,14 @@ export default class SignatoryService {
   }
 
   private updateSignatoryWithContactInfo(signatory: DirectorToSign, contactForm: DefineSignatoryInfoFormModel): void {
-    if (contactForm[`isSigning_${signatory.id}`] === SignatorySigning.WILL_SIGN) {
-      signatory.email = contactForm[`directorEmail_${signatory.id}`]
+    const signatoryId: string = signatory.id.toLowerCase()
+
+    if (contactForm[`isSigning_${signatoryId}`] === SignatorySigning.WILL_SIGN) {
+      signatory.email = contactForm[`directorEmail_${signatoryId}`]
       signatory.onBehalfName = undefined
     } else {
-      signatory.onBehalfName = contactForm[`onBehalfName_${signatory.id}`]
-      signatory.email = contactForm[`onBehalfEmail_${signatory.id}`]
+      signatory.onBehalfName = contactForm[`onBehalfName_${signatoryId}`]
+      signatory.email = contactForm[`onBehalfEmail_${signatoryId}`]
     }
   }
 }

--- a/src/services/signatories/signatory.validator.ts
+++ b/src/services/signatories/signatory.validator.ts
@@ -64,8 +64,10 @@ export default class SignatoryValidator {
   }
 
   private getProvidedEmailFieldForSignatory(signatory: DirectorToSign, form: DefineSignatoryInfoFormModel): string {
-    return form[`isSigning_${signatory.id}`] === SignatorySigning.WILL_SIGN ?
-      `directorEmail_${signatory.id}` : `onBehalfEmail_${signatory.id}`
+    const signatoryId: string = signatory.id.toLowerCase()
+
+    return form[`isSigning_${signatoryId}`] === SignatorySigning.WILL_SIGN ?
+      `directorEmail_${signatoryId}` : `onBehalfEmail_${signatoryId}`
   }
 
   private mapToValidationErrors(duplicates: SignatoryDetails[]): ValidationErrors {

--- a/src/views/components/define-signatory-info/signatory-details.njk
+++ b/src/views/components/define-signatory-info/signatory-details.njk
@@ -1,11 +1,26 @@
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/input/macro.njk"  import govukInput %}
 
+{% set signatoryId = (signatory.id | lower) %}
+{% set fieldsetId = "signatory_" + signatoryId %}
+
+{% set isSigningName = "isSigning_" + signatoryId %}
+{% set isSigningId = "is-signing_" + signatoryId %}
+
+{% set directorEmailName = "directorEmail_" + signatoryId %}
+{% set directorEmailId = "director-email_" + signatoryId %}
+
+{% set onBehalfNameName = "onBehalfName_" + signatoryId %}
+{% set onBehalfNameId = "on-behalf-name_" + signatoryId %}
+
+{% set onBehalfEmailName = "onBehalfEmail_" + signatoryId %}
+{% set onBehalfEmailId = "on-behalf-email_" + signatoryId %}
+
 {% set willSignSection %}
   {{
     govukInput({
-      id: "director-email_" + signatory.id,
-      name: "directorEmail_" + signatory.id,
+      id: directorEmailId,
+      name: directorEmailName,
       type: "email",
       autocomplete: "email",
       classes: "govuk-!-width-full",
@@ -16,12 +31,12 @@
         text: "We will use this to confirm their identity when they sign the application."
       },
       errorMessage: {
-        text: errors["directorEmail_" + signatory.id]
-      } if errors["directorEmail_" + signatory.id],
+        text: errors[directorEmailName]
+      } if errors[directorEmailName],
       attributes: {
         spellcheck: "false"
       },
-      value: data["directorEmail_" + signatory.id] if data
+      value: data[directorEmailName] if data
     })
   }}
 {% endset -%}
@@ -29,26 +44,26 @@
 {% set onBehalfSection %}
   {{
     govukInput({
-      id: "on-behalf-name_" + signatory.id,
-      name: "onBehalfName_" + signatory.id,
+      id: onBehalfNameId,
+      name: onBehalfNameName,
       classes: "govuk-!-width-full",
       label: {
         text: "What is the name of the person signing for " + signatory.name + "?"
       },
       errorMessage: {
-        text: errors["onBehalfName_" + signatory.id]
-      } if errors["onBehalfName_" + signatory.id],
+        text: errors[onBehalfNameName]
+      } if errors[onBehalfNameName],
       attributes: {
         spellcheck: "false"
       },
-      value: data["onBehalfName_" + signatory.id] if data
+      value: data[onBehalfNameName] if data
     })
   }}
 
   {{
     govukInput({
-      id: "on-behalf-email_" + signatory.id,
-      name: "onBehalfEmail_" + signatory.id,
+      id: onBehalfEmailId,
+      name: onBehalfEmailName,
       type: "email",
       autocomplete: "email",
       classes: "govuk-!-width-full",
@@ -59,23 +74,23 @@
         text: "We will use this to confirm their identity when they sign the application."
       },
       errorMessage: {
-        text: errors["onBehalfEmail_" + signatory.id]
-      } if errors["onBehalfEmail_" + signatory.id],
+        text: errors[onBehalfEmailName]
+      } if errors[onBehalfEmailName],
       attributes: {
         spellcheck: "false"
       },
-      value: data["onBehalfEmail_" + signatory.id] if data
+      value: data[onBehalfEmailName] if data
     })
   }}
 {% endset -%}
 
 {{
   govukRadios({
-    idPrefix: "is-signing_" + signatory.id,
-    name: "isSigning_" + signatory.id,
+    idPrefix: isSigningId,
+    name: isSigningName,
     fieldset: {
       attributes: {
-        id: "signatory_" + signatory.id
+        id: fieldsetId
       },
       legend: {
         text: signatory.name,
@@ -83,8 +98,8 @@
       }
     },
     errorMessage: {
-      text: errors["isSigning_" + signatory.id]
-    } if errors["isSigning_" + signatory.id],
+      text: errors[isSigningName]
+    } if errors[isSigningName],
     items: [
       {
         value: SignatorySigning.WILL_SIGN,
@@ -92,7 +107,7 @@
         conditional: {
           html: willSignSection
         },
-        checked: data["isSigning_" + signatory.id] === SignatorySigning.WILL_SIGN if data
+        checked: data[isSigningName] === SignatorySigning.WILL_SIGN if data
       },
       {
         value: SignatorySigning.ON_BEHALF,
@@ -100,7 +115,7 @@
         conditional: {
           html: onBehalfSection
         },
-        checked: data["isSigning_" + signatory.id] === SignatorySigning.ON_BEHALF if data
+        checked: data[isSigningName] === SignatorySigning.ON_BEHALF if data
       }
     ]
   })

--- a/test/controllers/defineSignatoryInfo.controller.test.ts
+++ b/test/controllers/defineSignatoryInfo.controller.test.ts
@@ -27,8 +27,11 @@ describe('DefineSignatoryInfoController', () => {
   let signatoryService: SignatoryService
 
   const APPLICANT_ID = '123'
-  const SIGNATORY_1_ID = '456'
-  const SIGNATORY_2_ID = '789'
+  const SIGNATORY_1_ID = '456AbC'
+  const SIGNATORY_2_ID = '789dEf'
+
+  const SIGNATORY_1_ID_LOWER = SIGNATORY_1_ID.toLowerCase()
+  const SIGNATORY_2_ID_LOWER = SIGNATORY_2_ID.toLowerCase()
 
   let dissolutionSession: DissolutionSession
 
@@ -73,35 +76,35 @@ describe('DefineSignatoryInfoController', () => {
 
       assert.isTrue(htmlAssertHelper.selectorDoesNotExist(`#signatory_${APPLICANT_ID}`))
 
-      assert.isTrue(htmlAssertHelper.selectorExists(`#signatory_${SIGNATORY_1_ID}`))
-      assert.isTrue(htmlAssertHelper.hasText(`#signatory_${SIGNATORY_1_ID} legend`, 'Jimmy McGuiness'))
-      assert.isTrue(htmlAssertHelper.selectorExists(`#is-signing_${SIGNATORY_1_ID}`))
-      assert.isTrue(htmlAssertHelper.selectorExists(`#is-signing_${SIGNATORY_1_ID}-2`))
-      assert.isTrue(htmlAssertHelper.selectorExists(`#director-email_${SIGNATORY_1_ID}`))
-      assert.isTrue(htmlAssertHelper.selectorExists(`#on-behalf-name_${SIGNATORY_1_ID}`))
-      assert.isTrue(htmlAssertHelper.selectorExists(`#on-behalf-email_${SIGNATORY_1_ID}`))
+      assert.isTrue(htmlAssertHelper.selectorExists(`#signatory_${SIGNATORY_1_ID_LOWER}`))
+      assert.isTrue(htmlAssertHelper.hasText(`#signatory_${SIGNATORY_1_ID_LOWER} legend`, 'Jimmy McGuiness'))
+      assert.isTrue(htmlAssertHelper.selectorExists(`#is-signing_${SIGNATORY_1_ID_LOWER}`))
+      assert.isTrue(htmlAssertHelper.selectorExists(`#is-signing_${SIGNATORY_1_ID_LOWER}-2`))
+      assert.isTrue(htmlAssertHelper.selectorExists(`#director-email_${SIGNATORY_1_ID_LOWER}`))
+      assert.isTrue(htmlAssertHelper.selectorExists(`#on-behalf-name_${SIGNATORY_1_ID_LOWER}`))
+      assert.isTrue(htmlAssertHelper.selectorExists(`#on-behalf-email_${SIGNATORY_1_ID_LOWER}`))
 
-      assert.isTrue(htmlAssertHelper.selectorExists(`#signatory_${SIGNATORY_2_ID}`))
-      assert.isTrue(htmlAssertHelper.hasText(`#signatory_${SIGNATORY_2_ID} legend`, 'Jane Smith'))
-      assert.isTrue(htmlAssertHelper.selectorExists(`#is-signing_${SIGNATORY_2_ID}`))
-      assert.isTrue(htmlAssertHelper.selectorExists(`#is-signing_${SIGNATORY_2_ID}-2`))
-      assert.isTrue(htmlAssertHelper.selectorExists(`#director-email_${SIGNATORY_2_ID}`))
-      assert.isTrue(htmlAssertHelper.selectorExists(`#on-behalf-name_${SIGNATORY_2_ID}`))
-      assert.isTrue(htmlAssertHelper.selectorExists(`#on-behalf-email_${SIGNATORY_2_ID}`))
+      assert.isTrue(htmlAssertHelper.selectorExists(`#signatory_${SIGNATORY_2_ID_LOWER}`))
+      assert.isTrue(htmlAssertHelper.hasText(`#signatory_${SIGNATORY_2_ID_LOWER} legend`, 'Jane Smith'))
+      assert.isTrue(htmlAssertHelper.selectorExists(`#is-signing_${SIGNATORY_2_ID_LOWER}`))
+      assert.isTrue(htmlAssertHelper.selectorExists(`#is-signing_${SIGNATORY_2_ID_LOWER}-2`))
+      assert.isTrue(htmlAssertHelper.selectorExists(`#director-email_${SIGNATORY_2_ID_LOWER}`))
+      assert.isTrue(htmlAssertHelper.selectorExists(`#on-behalf-name_${SIGNATORY_2_ID_LOWER}`))
+      assert.isTrue(htmlAssertHelper.selectorExists(`#on-behalf-email_${SIGNATORY_2_ID_LOWER}`))
     })
 
     it('should prepopulate the select director page with the selected director from session', async () => {
       const form: DefineSignatoryInfoFormModel = generateDefineSignatoryInfoFormModel()
 
-      form[`isSigning_${SIGNATORY_1_ID}`] = SignatorySigning.WILL_SIGN
-      form[`directorEmail_${SIGNATORY_1_ID}`] = 'director@mail.com'
-      form[`onBehalfName_${SIGNATORY_1_ID}`] = ''
-      form[`onBehalfEmail_${SIGNATORY_1_ID}`] = ''
+      form[`isSigning_${SIGNATORY_1_ID_LOWER}`] = SignatorySigning.WILL_SIGN
+      form[`directorEmail_${SIGNATORY_1_ID_LOWER}`] = 'director@mail.com'
+      form[`onBehalfName_${SIGNATORY_1_ID_LOWER}`] = ''
+      form[`onBehalfEmail_${SIGNATORY_1_ID_LOWER}`] = ''
 
-      form[`isSigning_${SIGNATORY_2_ID}`] = SignatorySigning.ON_BEHALF
-      form[`directorEmail_${SIGNATORY_2_ID}`] = ''
-      form[`onBehalfName_${SIGNATORY_2_ID}`] = 'Mr Accountant'
-      form[`onBehalfEmail_${SIGNATORY_2_ID}`] = 'accountant@mail.com'
+      form[`isSigning_${SIGNATORY_2_ID_LOWER}`] = SignatorySigning.ON_BEHALF
+      form[`directorEmail_${SIGNATORY_2_ID_LOWER}`] = ''
+      form[`onBehalfName_${SIGNATORY_2_ID_LOWER}`] = 'Mr Accountant'
+      form[`onBehalfEmail_${SIGNATORY_2_ID_LOWER}`] = 'accountant@mail.com'
 
       dissolutionSession.defineSignatoryInfoForm = form
 
@@ -117,17 +120,17 @@ describe('DefineSignatoryInfoController', () => {
 
       const htmlAssertHelper: HtmlAssertHelper = new HtmlAssertHelper(res.text)
 
-      assert.isTrue(htmlAssertHelper.hasAttribute(`#is-signing_${SIGNATORY_1_ID}`, 'checked'))
-      assert.isFalse(htmlAssertHelper.hasAttribute(`#is-signing_${SIGNATORY_1_ID}-2`, 'checked'))
-      assert.equal(htmlAssertHelper.getValue(`#director-email_${SIGNATORY_1_ID}`), 'director@mail.com')
-      assert.isNull(htmlAssertHelper.getValue(`#on-behalf-name_${SIGNATORY_1_ID}`))
-      assert.isNull(htmlAssertHelper.getValue(`#on-behalf-email_${SIGNATORY_1_ID}`))
+      assert.isTrue(htmlAssertHelper.hasAttribute(`#is-signing_${SIGNATORY_1_ID_LOWER}`, 'checked'))
+      assert.isFalse(htmlAssertHelper.hasAttribute(`#is-signing_${SIGNATORY_1_ID_LOWER}-2`, 'checked'))
+      assert.equal(htmlAssertHelper.getValue(`#director-email_${SIGNATORY_1_ID_LOWER}`), 'director@mail.com')
+      assert.isNull(htmlAssertHelper.getValue(`#on-behalf-name_${SIGNATORY_1_ID_LOWER}`))
+      assert.isNull(htmlAssertHelper.getValue(`#on-behalf-email_${SIGNATORY_1_ID_LOWER}`))
 
-      assert.isFalse(htmlAssertHelper.hasAttribute(`#is-signing_${SIGNATORY_2_ID}`, 'checked'))
-      assert.isTrue(htmlAssertHelper.hasAttribute(`#is-signing_${SIGNATORY_2_ID}-2`, 'checked'))
-      assert.isNull(htmlAssertHelper.getValue(`#director-email_${SIGNATORY_2_ID}`))
-      assert.equal(htmlAssertHelper.getValue(`#on-behalf-name_${SIGNATORY_2_ID}`), 'Mr Accountant')
-      assert.equal(htmlAssertHelper.getValue(`#on-behalf-email_${SIGNATORY_2_ID}`), 'accountant@mail.com')
+      assert.isFalse(htmlAssertHelper.hasAttribute(`#is-signing_${SIGNATORY_2_ID_LOWER}`, 'checked'))
+      assert.isTrue(htmlAssertHelper.hasAttribute(`#is-signing_${SIGNATORY_2_ID_LOWER}-2`, 'checked'))
+      assert.isNull(htmlAssertHelper.getValue(`#director-email_${SIGNATORY_2_ID_LOWER}`))
+      assert.equal(htmlAssertHelper.getValue(`#on-behalf-name_${SIGNATORY_2_ID_LOWER}`), 'Mr Accountant')
+      assert.equal(htmlAssertHelper.getValue(`#on-behalf-email_${SIGNATORY_2_ID_LOWER}`), 'accountant@mail.com')
     })
 
     describe('back button', () => {
@@ -179,7 +182,7 @@ describe('DefineSignatoryInfoController', () => {
 
     it('should re-render the view with an error if validation fails', async () => {
       const form: DefineSignatoryInfoFormModel = generateDefineSignatoryInfoFormModel()
-      const error: ValidationErrors = generateValidationError(`isSigning_${SIGNATORY_2_ID}`, 'some is signing error')
+      const error: ValidationErrors = generateValidationError(`isSigning_${SIGNATORY_2_ID_LOWER}`, 'some is signing error')
 
       when(session.getDissolutionSession(anything())).thenReturn(dissolutionSession)
       when(signatoryService.validateSignatoryInfo(anything(), deepEqual(form))).thenReturn(error)
@@ -194,7 +197,7 @@ describe('DefineSignatoryInfoController', () => {
       const htmlAssertHelper: HtmlAssertHelper = new HtmlAssertHelper(res.text)
 
       assert.isTrue(htmlAssertHelper.selectorExists('.govuk-error-summary'))
-      assert.isTrue(htmlAssertHelper.containsText(`#is-signing_${SIGNATORY_2_ID}-error`, 'some is signing error'))
+      assert.isTrue(htmlAssertHelper.containsText(`#is-signing_${SIGNATORY_2_ID_LOWER}-error`, 'some is signing error'))
     })
 
     describe('session', () => {

--- a/test/fixtures/companyOfficers.fixtures.ts
+++ b/test/fixtures/companyOfficers.fixtures.ts
@@ -111,10 +111,10 @@ export function generateSelectSignatoriesFormModel(...signatories: string[]): Se
 
 export function generateDefineSignatoryInfoFormModel(): DefineSignatoryInfoFormModel {
   return {
-    isSigning_123: SignatorySigning.WILL_SIGN,
-    directorEmail_123: 'director@mail.com',
-    isSigning_456: SignatorySigning.ON_BEHALF,
-    onBehalfName_456: 'Mr Accountant',
-    onBehalfEmail_456: 'accountant@mail.com'
+    isSigning_123abc: SignatorySigning.WILL_SIGN,
+    directorEmail_123abc: 'director@mail.com',
+    isSigning_456def: SignatorySigning.ON_BEHALF,
+    onBehalfName_456def: 'Mr Accountant',
+    onBehalfEmail_456def: 'accountant@mail.com'
   }
 }

--- a/test/schemas/defineSignatoryInfo.schema.test.ts
+++ b/test/schemas/defineSignatoryInfo.schema.test.ts
@@ -9,8 +9,11 @@ import defineSignatoryInfoSchema from 'app/schemas/defineSignatoryInfo.schema'
 
 describe('Define Signatory Info Schema', () => {
 
-  const SIGNATORY_1_ID = '123'
-  const SIGNATORY_2_ID = '456'
+  const SIGNATORY_1_ID = '123AbC'
+  const SIGNATORY_2_ID = '456dEf'
+
+  const SIGNATORY_1_ID_LOWER = SIGNATORY_1_ID.toLowerCase()
+  const SIGNATORY_2_ID_LOWER = SIGNATORY_2_ID.toLowerCase()
 
   const SIGNATORY_1_NAME = 'Signatory 1'
   const SIGNATORY_2_NAME = 'Signatory 2'
@@ -31,15 +34,15 @@ describe('Define Signatory Info Schema', () => {
   it('should return no errors when data is valid', () => {
     const form: DefineSignatoryInfoFormModel = generateDefineSignatoryInfoFormModel()
 
-    form[`isSigning_${SIGNATORY_1_ID}`] = SignatorySigning.WILL_SIGN
-    form[`directorEmail_${SIGNATORY_1_ID}`] = 'director@mail.com'
-    form[`onBehalfName_${SIGNATORY_1_ID}`] = ''
-    form[`onBehalfEmail_${SIGNATORY_1_ID}`] = ''
+    form[`isSigning_${SIGNATORY_1_ID_LOWER}`] = SignatorySigning.WILL_SIGN
+    form[`directorEmail_${SIGNATORY_1_ID_LOWER}`] = 'director@mail.com'
+    form[`onBehalfName_${SIGNATORY_1_ID_LOWER}`] = ''
+    form[`onBehalfEmail_${SIGNATORY_1_ID_LOWER}`] = ''
 
-    form[`isSigning_${SIGNATORY_2_ID}`] = SignatorySigning.ON_BEHALF
-    form[`directorEmail_${SIGNATORY_2_ID}`] = ''
-    form[`onBehalfName_${SIGNATORY_2_ID}`] = 'Mr Accountant'
-    form[`onBehalfEmail_${SIGNATORY_2_ID}`] = 'accountant@mail.com'
+    form[`isSigning_${SIGNATORY_2_ID_LOWER}`] = SignatorySigning.ON_BEHALF
+    form[`directorEmail_${SIGNATORY_2_ID_LOWER}`] = ''
+    form[`onBehalfName_${SIGNATORY_2_ID_LOWER}`] = 'Mr Accountant'
+    form[`onBehalfEmail_${SIGNATORY_2_ID_LOWER}`] = 'accountant@mail.com'
 
     const errors: ValidationResult = defineSignatoryInfoSchema([signatory1, signatory2]).validate(form, { abortEarly: false })
 
@@ -49,26 +52,26 @@ describe('Define Signatory Info Schema', () => {
   it('should return an error when it has not been provided how a signatory will be signing', () => {
     const form: DefineSignatoryInfoFormModel = generateDefineSignatoryInfoFormModel()
 
-    form[`isSigning_${SIGNATORY_1_ID}`] = ''
-    form[`directorEmail_${SIGNATORY_1_ID}`] = 'director@mail.com'
-    form[`onBehalfName_${SIGNATORY_1_ID}`] = ''
-    form[`onBehalfEmail_${SIGNATORY_1_ID}`] = ''
+    form[`isSigning_${SIGNATORY_1_ID_LOWER}`] = ''
+    form[`directorEmail_${SIGNATORY_1_ID_LOWER}`] = 'director@mail.com'
+    form[`onBehalfName_${SIGNATORY_1_ID_LOWER}`] = ''
+    form[`onBehalfEmail_${SIGNATORY_1_ID_LOWER}`] = ''
 
-    form[`isSigning_${SIGNATORY_2_ID}`] = SignatorySigning.ON_BEHALF
-    form[`directorEmail_${SIGNATORY_2_ID}`] = ''
-    form[`onBehalfName_${SIGNATORY_2_ID}`] = 'Mr Accountant'
-    form[`onBehalfEmail_${SIGNATORY_2_ID}`] = 'accountant@mail.com'
+    form[`isSigning_${SIGNATORY_2_ID_LOWER}`] = SignatorySigning.ON_BEHALF
+    form[`directorEmail_${SIGNATORY_2_ID_LOWER}`] = ''
+    form[`onBehalfName_${SIGNATORY_2_ID_LOWER}`] = 'Mr Accountant'
+    form[`onBehalfEmail_${SIGNATORY_2_ID_LOWER}`] = 'accountant@mail.com'
 
     const errors: ValidationResult = defineSignatoryInfoSchema([signatory1, signatory2]).validate(form, { abortEarly: false })
 
     assert.isDefined(errors.error)
     assert.equal(errors.error!.details.length, 2)
 
-    assert.equal(errors.error!.details[0].context!.key, `isSigning_${SIGNATORY_1_ID}`)
+    assert.equal(errors.error!.details[0].context!.key, `isSigning_${SIGNATORY_1_ID_LOWER}`)
     assert.equal(errors.error!.details[0].type, `any.only`)
     assert.equal(errors.error!.details[0].message, `Select how ${SIGNATORY_1_NAME} will be signing the application`)
 
-    assert.equal(errors.error!.details[1].context!.key, `isSigning_${SIGNATORY_1_ID}`)
+    assert.equal(errors.error!.details[1].context!.key, `isSigning_${SIGNATORY_1_ID_LOWER}`)
     assert.equal(errors.error!.details[1].type, `string.empty`)
     assert.equal(errors.error!.details[1].message, `Select how ${SIGNATORY_1_NAME} will be signing the application`)
   })
@@ -76,30 +79,30 @@ describe('Define Signatory Info Schema', () => {
   it('should return an error if mandatory text fields have not been provided', () => {
     const form: DefineSignatoryInfoFormModel = generateDefineSignatoryInfoFormModel()
 
-    form[`isSigning_${SIGNATORY_1_ID}`] = SignatorySigning.WILL_SIGN
-    form[`directorEmail_${SIGNATORY_1_ID}`] = ''
-    form[`onBehalfName_${SIGNATORY_1_ID}`] = ''
-    form[`onBehalfEmail_${SIGNATORY_1_ID}`] = ''
+    form[`isSigning_${SIGNATORY_1_ID_LOWER}`] = SignatorySigning.WILL_SIGN
+    form[`directorEmail_${SIGNATORY_1_ID_LOWER}`] = ''
+    form[`onBehalfName_${SIGNATORY_1_ID_LOWER}`] = ''
+    form[`onBehalfEmail_${SIGNATORY_1_ID_LOWER}`] = ''
 
-    form[`isSigning_${SIGNATORY_2_ID}`] = SignatorySigning.ON_BEHALF
-    form[`directorEmail_${SIGNATORY_2_ID}`] = ''
-    form[`onBehalfName_${SIGNATORY_2_ID}`] = ''
-    form[`onBehalfEmail_${SIGNATORY_2_ID}`] = ''
+    form[`isSigning_${SIGNATORY_2_ID_LOWER}`] = SignatorySigning.ON_BEHALF
+    form[`directorEmail_${SIGNATORY_2_ID_LOWER}`] = ''
+    form[`onBehalfName_${SIGNATORY_2_ID_LOWER}`] = ''
+    form[`onBehalfEmail_${SIGNATORY_2_ID_LOWER}`] = ''
 
     const errors: ValidationResult = defineSignatoryInfoSchema([signatory1, signatory2]).validate(form, { abortEarly: false })
 
     assert.isDefined(errors.error)
     assert.equal(errors.error!.details.length, 3)
 
-    assert.equal(errors.error!.details[0].context!.key, `directorEmail_${SIGNATORY_1_ID}`)
+    assert.equal(errors.error!.details[0].context!.key, `directorEmail_${SIGNATORY_1_ID_LOWER}`)
     assert.equal(errors.error!.details[0].type, `string.empty`)
     assert.equal(errors.error!.details[0].message, `Enter the email address for ${SIGNATORY_1_NAME}`)
 
-    assert.equal(errors.error!.details[1].context!.key, `onBehalfName_${SIGNATORY_2_ID}`)
+    assert.equal(errors.error!.details[1].context!.key, `onBehalfName_${SIGNATORY_2_ID_LOWER}`)
     assert.equal(errors.error!.details[1].type, `string.empty`)
     assert.equal(errors.error!.details[1].message, `Enter the name for the person signing on behalf of ${SIGNATORY_2_NAME}`)
 
-    assert.equal(errors.error!.details[2].context!.key, `onBehalfEmail_${SIGNATORY_2_ID}`)
+    assert.equal(errors.error!.details[2].context!.key, `onBehalfEmail_${SIGNATORY_2_ID_LOWER}`)
     assert.equal(errors.error!.details[2].type, `string.empty`)
     assert.equal(errors.error!.details[2].message, `Enter the email address for the person signing on behalf of ${SIGNATORY_2_NAME}`)
   })
@@ -107,26 +110,26 @@ describe('Define Signatory Info Schema', () => {
   it('should return an error if email fields do not contain valid email values', () => {
     const form: DefineSignatoryInfoFormModel = generateDefineSignatoryInfoFormModel()
 
-    form[`isSigning_${SIGNATORY_1_ID}`] = SignatorySigning.WILL_SIGN
-    form[`directorEmail_${SIGNATORY_1_ID}`] = 'not an email'
-    form[`onBehalfName_${SIGNATORY_1_ID}`] = ''
-    form[`onBehalfEmail_${SIGNATORY_1_ID}`] = ''
+    form[`isSigning_${SIGNATORY_1_ID_LOWER}`] = SignatorySigning.WILL_SIGN
+    form[`directorEmail_${SIGNATORY_1_ID_LOWER}`] = 'not an email'
+    form[`onBehalfName_${SIGNATORY_1_ID_LOWER}`] = ''
+    form[`onBehalfEmail_${SIGNATORY_1_ID_LOWER}`] = ''
 
-    form[`isSigning_${SIGNATORY_2_ID}`] = SignatorySigning.ON_BEHALF
-    form[`directorEmail_${SIGNATORY_2_ID}`] = ''
-    form[`onBehalfName_${SIGNATORY_2_ID}`] = 'Mr Accountant'
-    form[`onBehalfEmail_${SIGNATORY_2_ID}`] = 'also not an email'
+    form[`isSigning_${SIGNATORY_2_ID_LOWER}`] = SignatorySigning.ON_BEHALF
+    form[`directorEmail_${SIGNATORY_2_ID_LOWER}`] = ''
+    form[`onBehalfName_${SIGNATORY_2_ID_LOWER}`] = 'Mr Accountant'
+    form[`onBehalfEmail_${SIGNATORY_2_ID_LOWER}`] = 'also not an email'
 
     const errors: ValidationResult = defineSignatoryInfoSchema([signatory1, signatory2]).validate(form, { abortEarly: false })
 
     assert.isDefined(errors.error)
     assert.equal(errors.error!.details.length, 2)
 
-    assert.equal(errors.error!.details[0].context!.key, `directorEmail_${SIGNATORY_1_ID}`)
+    assert.equal(errors.error!.details[0].context!.key, `directorEmail_${SIGNATORY_1_ID_LOWER}`)
     assert.equal(errors.error!.details[0].type, `string.email`)
     assert.equal(errors.error!.details[0].message, `Enter a valid email address for ${SIGNATORY_1_NAME}`)
 
-    assert.equal(errors.error!.details[1].context!.key, `onBehalfEmail_${SIGNATORY_2_ID}`)
+    assert.equal(errors.error!.details[1].context!.key, `onBehalfEmail_${SIGNATORY_2_ID_LOWER}`)
     assert.equal(errors.error!.details[1].type, `string.email`)
     assert.equal(errors.error!.details[1].message, `Enter a valid email address for the person signing on behalf of ${SIGNATORY_2_NAME}`)
   })
@@ -134,22 +137,22 @@ describe('Define Signatory Info Schema', () => {
   it('should return an error if a name is provided that is above the maximum length', () => {
     const form: DefineSignatoryInfoFormModel = generateDefineSignatoryInfoFormModel()
 
-    form[`isSigning_${SIGNATORY_1_ID}`] = SignatorySigning.WILL_SIGN
-    form[`directorEmail_${SIGNATORY_1_ID}`] = 'director@mail.com'
-    form[`onBehalfName_${SIGNATORY_1_ID}`] = ''
-    form[`onBehalfEmail_${SIGNATORY_1_ID}`] = ''
+    form[`isSigning_${SIGNATORY_1_ID_LOWER}`] = SignatorySigning.WILL_SIGN
+    form[`directorEmail_${SIGNATORY_1_ID_LOWER}`] = 'director@mail.com'
+    form[`onBehalfName_${SIGNATORY_1_ID_LOWER}`] = ''
+    form[`onBehalfEmail_${SIGNATORY_1_ID_LOWER}`] = ''
 
-    form[`isSigning_${SIGNATORY_2_ID}`] = SignatorySigning.ON_BEHALF
-    form[`directorEmail_${SIGNATORY_2_ID}`] = ''
-    form[`onBehalfName_${SIGNATORY_2_ID}`] = 'X'.repeat(251)
-    form[`onBehalfEmail_${SIGNATORY_2_ID}`] = 'accountant@mail.com'
+    form[`isSigning_${SIGNATORY_2_ID_LOWER}`] = SignatorySigning.ON_BEHALF
+    form[`directorEmail_${SIGNATORY_2_ID_LOWER}`] = ''
+    form[`onBehalfName_${SIGNATORY_2_ID_LOWER}`] = 'X'.repeat(251)
+    form[`onBehalfEmail_${SIGNATORY_2_ID_LOWER}`] = 'accountant@mail.com'
 
     const errors: ValidationResult = defineSignatoryInfoSchema([signatory1, signatory2]).validate(form, { abortEarly: false })
 
     assert.isDefined(errors.error)
     assert.equal(errors.error!.details.length, 1)
 
-    assert.equal(errors.error!.details[0].context!.key, `onBehalfName_${SIGNATORY_2_ID}`)
+    assert.equal(errors.error!.details[0].context!.key, `onBehalfName_${SIGNATORY_2_ID_LOWER}`)
     assert.equal(errors.error!.details[0].type, `string.max`)
     assert.equal(errors.error!.details[0].message, `Enter a name that is less than 250 characters for the person signing on behalf of ${SIGNATORY_2_NAME}`)
   })
@@ -157,15 +160,15 @@ describe('Define Signatory Info Schema', () => {
   it('should ignore invalid fields if the associated radio option has not been selected', () => {
     const form: DefineSignatoryInfoFormModel = generateDefineSignatoryInfoFormModel()
 
-    form[`isSigning_${SIGNATORY_1_ID}`] = SignatorySigning.WILL_SIGN
-    form[`directorEmail_${SIGNATORY_1_ID}`] = 'director@mail.com'
-    form[`onBehalfName_${SIGNATORY_1_ID}`] = 'X'.repeat(500)
-    form[`onBehalfEmail_${SIGNATORY_1_ID}`] = 'not an email'
+    form[`isSigning_${SIGNATORY_1_ID_LOWER}`] = SignatorySigning.WILL_SIGN
+    form[`directorEmail_${SIGNATORY_1_ID_LOWER}`] = 'director@mail.com'
+    form[`onBehalfName_${SIGNATORY_1_ID_LOWER}`] = 'X'.repeat(500)
+    form[`onBehalfEmail_${SIGNATORY_1_ID_LOWER}`] = 'not an email'
 
-    form[`isSigning_${SIGNATORY_2_ID}`] = SignatorySigning.ON_BEHALF
-    form[`directorEmail_${SIGNATORY_2_ID}`] = 'also not an email'
-    form[`onBehalfName_${SIGNATORY_2_ID}`] = 'Mr Accountant'
-    form[`onBehalfEmail_${SIGNATORY_2_ID}`] = 'accountant@mail.com'
+    form[`isSigning_${SIGNATORY_2_ID_LOWER}`] = SignatorySigning.ON_BEHALF
+    form[`directorEmail_${SIGNATORY_2_ID_LOWER}`] = 'also not an email'
+    form[`onBehalfName_${SIGNATORY_2_ID_LOWER}`] = 'Mr Accountant'
+    form[`onBehalfEmail_${SIGNATORY_2_ID_LOWER}`] = 'accountant@mail.com'
 
     const errors: ValidationResult = defineSignatoryInfoSchema([signatory1, signatory2]).validate(form, { abortEarly: false })
 

--- a/test/services/signatories/signatory.service.test.ts
+++ b/test/services/signatories/signatory.service.test.ts
@@ -90,6 +90,9 @@ describe('SignatoryService', () => {
     const SIGNATORY_1_ID = '123'
     const SIGNATORY_2_ID = '456'
 
+    const SIGNATORY_1_ID_LOWER = SIGNATORY_1_ID.toLowerCase()
+    const SIGNATORY_2_ID_LOWER = SIGNATORY_2_ID.toLowerCase()
+
     let signatory1: DirectorToSign
     let signatory2: DirectorToSign
 
@@ -104,15 +107,15 @@ describe('SignatoryService', () => {
     it('should update signatories with their contact info if they will sign the application themselves', () => {
       const contactForm: DefineSignatoryInfoFormModel = generateDefineSignatoryInfoFormModel()
 
-      contactForm[`isSigning_${SIGNATORY_1_ID}`] = SignatorySigning.WILL_SIGN
-      contactForm[`directorEmail_${SIGNATORY_1_ID}`] = 'director@mail.com'
-      contactForm[`onBehalfName_${SIGNATORY_1_ID}`] = ''
-      contactForm[`onBehalfEmail_${SIGNATORY_1_ID}`] = ''
+      contactForm[`isSigning_${SIGNATORY_1_ID_LOWER}`] = SignatorySigning.WILL_SIGN
+      contactForm[`directorEmail_${SIGNATORY_1_ID_LOWER}`] = 'director@mail.com'
+      contactForm[`onBehalfName_${SIGNATORY_1_ID_LOWER}`] = ''
+      contactForm[`onBehalfEmail_${SIGNATORY_1_ID_LOWER}`] = ''
 
-      contactForm[`isSigning_${SIGNATORY_2_ID}`] = SignatorySigning.WILL_SIGN
-      contactForm[`directorEmail_${SIGNATORY_2_ID}`] = 'otherDirector@mail.com'
-      contactForm[`onBehalfName_${SIGNATORY_2_ID}`] = ''
-      contactForm[`onBehalfEmail_${SIGNATORY_2_ID}`] = ''
+      contactForm[`isSigning_${SIGNATORY_2_ID_LOWER}`] = SignatorySigning.WILL_SIGN
+      contactForm[`directorEmail_${SIGNATORY_2_ID_LOWER}`] = 'otherDirector@mail.com'
+      contactForm[`onBehalfName_${SIGNATORY_2_ID_LOWER}`] = ''
+      contactForm[`onBehalfEmail_${SIGNATORY_2_ID_LOWER}`] = ''
 
       service.updateSignatoriesWithContactInfo([signatory1, signatory2], contactForm)
 
@@ -126,15 +129,15 @@ describe('SignatoryService', () => {
     it('should update signatories with their contact info if someone will sign the application on behalf of them', () => {
       const contactForm: DefineSignatoryInfoFormModel = generateDefineSignatoryInfoFormModel()
 
-      contactForm[`isSigning_${SIGNATORY_1_ID}`] = SignatorySigning.ON_BEHALF
-      contactForm[`directorEmail_${SIGNATORY_1_ID}`] = ''
-      contactForm[`onBehalfName_${SIGNATORY_1_ID}`] = 'Mr Accountant'
-      contactForm[`onBehalfEmail_${SIGNATORY_1_ID}`] = 'accountant@mail.com'
+      contactForm[`isSigning_${SIGNATORY_1_ID_LOWER}`] = SignatorySigning.ON_BEHALF
+      contactForm[`directorEmail_${SIGNATORY_1_ID_LOWER}`] = ''
+      contactForm[`onBehalfName_${SIGNATORY_1_ID_LOWER}`] = 'Mr Accountant'
+      contactForm[`onBehalfEmail_${SIGNATORY_1_ID_LOWER}`] = 'accountant@mail.com'
 
-      contactForm[`isSigning_${SIGNATORY_2_ID}`] = SignatorySigning.ON_BEHALF
-      contactForm[`directorEmail_${SIGNATORY_2_ID}`] = ''
-      contactForm[`onBehalfName_${SIGNATORY_2_ID}`] = 'Miss Solicitor'
-      contactForm[`onBehalfEmail_${SIGNATORY_2_ID}`] = 'solicitor@mail.com'
+      contactForm[`isSigning_${SIGNATORY_2_ID_LOWER}`] = SignatorySigning.ON_BEHALF
+      contactForm[`directorEmail_${SIGNATORY_2_ID_LOWER}`] = ''
+      contactForm[`onBehalfName_${SIGNATORY_2_ID_LOWER}`] = 'Miss Solicitor'
+      contactForm[`onBehalfEmail_${SIGNATORY_2_ID_LOWER}`] = 'solicitor@mail.com'
 
       service.updateSignatoriesWithContactInfo([signatory1, signatory2], contactForm)
 
@@ -148,15 +151,15 @@ describe('SignatoryService', () => {
     it('should handle multiple signatories selecting different options for signing preference', () => {
       const contactForm: DefineSignatoryInfoFormModel = generateDefineSignatoryInfoFormModel()
 
-      contactForm[`isSigning_${SIGNATORY_1_ID}`] = SignatorySigning.ON_BEHALF
-      contactForm[`directorEmail_${SIGNATORY_1_ID}`] = ''
-      contactForm[`onBehalfName_${SIGNATORY_1_ID}`] = 'Mr Accountant'
-      contactForm[`onBehalfEmail_${SIGNATORY_1_ID}`] = 'accountant@mail.com'
+      contactForm[`isSigning_${SIGNATORY_1_ID_LOWER}`] = SignatorySigning.ON_BEHALF
+      contactForm[`directorEmail_${SIGNATORY_1_ID_LOWER}`] = ''
+      contactForm[`onBehalfName_${SIGNATORY_1_ID_LOWER}`] = 'Mr Accountant'
+      contactForm[`onBehalfEmail_${SIGNATORY_1_ID_LOWER}`] = 'accountant@mail.com'
 
-      contactForm[`isSigning_${SIGNATORY_2_ID}`] = SignatorySigning.WILL_SIGN
-      contactForm[`directorEmail_${SIGNATORY_2_ID}`] = 'director@mail.com'
-      contactForm[`onBehalfName_${SIGNATORY_2_ID}`] = ''
-      contactForm[`onBehalfEmail_${SIGNATORY_2_ID}`] = ''
+      contactForm[`isSigning_${SIGNATORY_2_ID_LOWER}`] = SignatorySigning.WILL_SIGN
+      contactForm[`directorEmail_${SIGNATORY_2_ID_LOWER}`] = 'director@mail.com'
+      contactForm[`onBehalfName_${SIGNATORY_2_ID_LOWER}`] = ''
+      contactForm[`onBehalfEmail_${SIGNATORY_2_ID_LOWER}`] = ''
 
       service.updateSignatoriesWithContactInfo([signatory1, signatory2], contactForm)
 

--- a/test/services/signatories/signatory.validator.test.ts
+++ b/test/services/signatories/signatory.validator.test.ts
@@ -24,8 +24,11 @@ describe('SignatoryValidator', () => {
   })
 
   describe('validateSignatoryInfo', () => {
-    const SIGNATORY_1_ID = '123'
-    const SIGNATORY_2_ID = '456'
+    const SIGNATORY_1_ID = '123AbC'
+    const SIGNATORY_2_ID = '456dEf'
+
+    const SIGNATORY_1_ID_LOWER = SIGNATORY_1_ID.toLowerCase()
+    const SIGNATORY_2_ID_LOWER = SIGNATORY_2_ID.toLowerCase()
 
     const SIGNATORY_1_NAME = 'Signatory 1'
     const SIGNATORY_2_NAME = 'Signatory 2'
@@ -60,81 +63,81 @@ describe('SignatoryValidator', () => {
     it('should return validation errors if duplicate emails have been provided for signatories who will sign', () => {
       const form: DefineSignatoryInfoFormModel = generateDefineSignatoryInfoFormModel()
 
-      form[`isSigning_${SIGNATORY_1_ID}`] = SignatorySigning.WILL_SIGN
-      form[`directorEmail_${SIGNATORY_1_ID}`] = 'director@mail.com'
-      form[`onBehalfName_${SIGNATORY_1_ID}`] = ''
-      form[`onBehalfEmail_${SIGNATORY_1_ID}`] = ''
+      form[`isSigning_${SIGNATORY_1_ID_LOWER}`] = SignatorySigning.WILL_SIGN
+      form[`directorEmail_${SIGNATORY_1_ID_LOWER}`] = 'director@mail.com'
+      form[`onBehalfName_${SIGNATORY_1_ID_LOWER}`] = ''
+      form[`onBehalfEmail_${SIGNATORY_1_ID_LOWER}`] = ''
 
-      form[`isSigning_${SIGNATORY_2_ID}`] = SignatorySigning.WILL_SIGN
-      form[`directorEmail_${SIGNATORY_2_ID}`] = 'director@mail.com'
-      form[`onBehalfName_${SIGNATORY_2_ID}`] = ''
-      form[`onBehalfEmail_${SIGNATORY_2_ID}`] = ''
+      form[`isSigning_${SIGNATORY_2_ID_LOWER}`] = SignatorySigning.WILL_SIGN
+      form[`directorEmail_${SIGNATORY_2_ID_LOWER}`] = 'director@mail.com'
+      form[`onBehalfName_${SIGNATORY_2_ID_LOWER}`] = ''
+      form[`onBehalfEmail_${SIGNATORY_2_ID_LOWER}`] = ''
 
       when(formValidator.validate(deepEqual(form), anything())).thenReturn(null)
 
       const result: Optional<ValidationErrors> = service.validateSignatoryInfo([signatory1, signatory2], form)
 
       assert.equal(Object.keys(result!).length, 2)
-      assert.equal(result![`directorEmail_${SIGNATORY_1_ID}`], `Enter a unique email address for ${SIGNATORY_1_NAME}`)
-      assert.equal(result![`directorEmail_${SIGNATORY_2_ID}`], `Enter a unique email address for ${SIGNATORY_2_NAME}`)
+      assert.equal(result![`directorEmail_${SIGNATORY_1_ID_LOWER}`], `Enter a unique email address for ${SIGNATORY_1_NAME}`)
+      assert.equal(result![`directorEmail_${SIGNATORY_2_ID_LOWER}`], `Enter a unique email address for ${SIGNATORY_2_NAME}`)
     })
 
     it('should return validation errors if duplicate emails have been provided for signatories who will be signed on behalf', () => {
       const form: DefineSignatoryInfoFormModel = generateDefineSignatoryInfoFormModel()
 
-      form[`isSigning_${SIGNATORY_1_ID}`] = SignatorySigning.ON_BEHALF
-      form[`directorEmail_${SIGNATORY_1_ID}`] = ''
-      form[`onBehalfName_${SIGNATORY_1_ID}`] = 'Mr Accountant'
-      form[`onBehalfEmail_${SIGNATORY_1_ID}`] = 'accountant@mail.com'
+      form[`isSigning_${SIGNATORY_1_ID_LOWER}`] = SignatorySigning.ON_BEHALF
+      form[`directorEmail_${SIGNATORY_1_ID_LOWER}`] = ''
+      form[`onBehalfName_${SIGNATORY_1_ID_LOWER}`] = 'Mr Accountant'
+      form[`onBehalfEmail_${SIGNATORY_1_ID_LOWER}`] = 'accountant@mail.com'
 
-      form[`isSigning_${SIGNATORY_2_ID}`] = SignatorySigning.ON_BEHALF
-      form[`directorEmail_${SIGNATORY_2_ID}`] = ''
-      form[`onBehalfName_${SIGNATORY_2_ID}`] = 'Another Accountant'
-      form[`onBehalfEmail_${SIGNATORY_2_ID}`] = 'accountant@mail.com'
+      form[`isSigning_${SIGNATORY_2_ID_LOWER}`] = SignatorySigning.ON_BEHALF
+      form[`directorEmail_${SIGNATORY_2_ID_LOWER}`] = ''
+      form[`onBehalfName_${SIGNATORY_2_ID_LOWER}`] = 'Another Accountant'
+      form[`onBehalfEmail_${SIGNATORY_2_ID_LOWER}`] = 'accountant@mail.com'
 
       when(formValidator.validate(deepEqual(form), anything())).thenReturn(null)
 
       const result: Optional<ValidationErrors> = service.validateSignatoryInfo([signatory1, signatory2], form)
 
       assert.equal(Object.keys(result!).length, 2)
-      assert.equal(result![`onBehalfEmail_${SIGNATORY_1_ID}`], `Enter a unique email address for ${SIGNATORY_1_NAME}`)
-      assert.equal(result![`onBehalfEmail_${SIGNATORY_2_ID}`], `Enter a unique email address for ${SIGNATORY_2_NAME}`)
+      assert.equal(result![`onBehalfEmail_${SIGNATORY_1_ID_LOWER}`], `Enter a unique email address for ${SIGNATORY_1_NAME}`)
+      assert.equal(result![`onBehalfEmail_${SIGNATORY_2_ID_LOWER}`], `Enter a unique email address for ${SIGNATORY_2_NAME}`)
     })
 
     it('should return validation errors if duplicate emails have been provided for alternative signing options', () => {
       const form: DefineSignatoryInfoFormModel = generateDefineSignatoryInfoFormModel()
 
-      form[`isSigning_${SIGNATORY_1_ID}`] = SignatorySigning.WILL_SIGN
-      form[`directorEmail_${SIGNATORY_1_ID}`] = 'mixed@mail.com'
-      form[`onBehalfName_${SIGNATORY_1_ID}`] = ''
-      form[`onBehalfEmail_${SIGNATORY_1_ID}`] = ''
+      form[`isSigning_${SIGNATORY_1_ID_LOWER}`] = SignatorySigning.WILL_SIGN
+      form[`directorEmail_${SIGNATORY_1_ID_LOWER}`] = 'mixed@mail.com'
+      form[`onBehalfName_${SIGNATORY_1_ID_LOWER}`] = ''
+      form[`onBehalfEmail_${SIGNATORY_1_ID_LOWER}`] = ''
 
-      form[`isSigning_${SIGNATORY_2_ID}`] = SignatorySigning.ON_BEHALF
-      form[`directorEmail_${SIGNATORY_2_ID}`] = ''
-      form[`onBehalfName_${SIGNATORY_2_ID}`] = 'Someone else'
-      form[`onBehalfEmail_${SIGNATORY_2_ID}`] = 'mixed@mail.com'
+      form[`isSigning_${SIGNATORY_2_ID_LOWER}`] = SignatorySigning.ON_BEHALF
+      form[`directorEmail_${SIGNATORY_2_ID_LOWER}`] = ''
+      form[`onBehalfName_${SIGNATORY_2_ID_LOWER}`] = 'Someone else'
+      form[`onBehalfEmail_${SIGNATORY_2_ID_LOWER}`] = 'mixed@mail.com'
 
       when(formValidator.validate(deepEqual(form), anything())).thenReturn(null)
 
       const result: Optional<ValidationErrors> = service.validateSignatoryInfo([signatory1, signatory2], form)
 
       assert.equal(Object.keys(result!).length, 2)
-      assert.equal(result![`directorEmail_${SIGNATORY_1_ID}`], `Enter a unique email address for ${SIGNATORY_1_NAME}`)
-      assert.equal(result![`onBehalfEmail_${SIGNATORY_2_ID}`], `Enter a unique email address for ${SIGNATORY_2_NAME}`)
+      assert.equal(result![`directorEmail_${SIGNATORY_1_ID_LOWER}`], `Enter a unique email address for ${SIGNATORY_1_NAME}`)
+      assert.equal(result![`onBehalfEmail_${SIGNATORY_2_ID_LOWER}`], `Enter a unique email address for ${SIGNATORY_2_NAME}`)
     })
 
     it('should return no validation errors if unique emails have been provided', () => {
       const form: DefineSignatoryInfoFormModel = generateDefineSignatoryInfoFormModel()
 
-      form[`isSigning_${SIGNATORY_1_ID}`] = SignatorySigning.WILL_SIGN
-      form[`directorEmail_${SIGNATORY_1_ID}`] = 'director@mail.com'
-      form[`onBehalfName_${SIGNATORY_1_ID}`] = ''
-      form[`onBehalfEmail_${SIGNATORY_1_ID}`] = ''
+      form[`isSigning_${SIGNATORY_1_ID_LOWER}`] = SignatorySigning.WILL_SIGN
+      form[`directorEmail_${SIGNATORY_1_ID_LOWER}`] = 'director@mail.com'
+      form[`onBehalfName_${SIGNATORY_1_ID_LOWER}`] = ''
+      form[`onBehalfEmail_${SIGNATORY_1_ID_LOWER}`] = ''
 
-      form[`isSigning_${SIGNATORY_2_ID}`] = SignatorySigning.ON_BEHALF
-      form[`directorEmail_${SIGNATORY_2_ID}`] = ''
-      form[`onBehalfName_${SIGNATORY_2_ID}`] = 'Mr Accountant'
-      form[`onBehalfEmail_${SIGNATORY_2_ID}`] = 'accountant@mail.com'
+      form[`isSigning_${SIGNATORY_2_ID_LOWER}`] = SignatorySigning.ON_BEHALF
+      form[`directorEmail_${SIGNATORY_2_ID_LOWER}`] = ''
+      form[`onBehalfName_${SIGNATORY_2_ID_LOWER}`] = 'Mr Accountant'
+      form[`onBehalfEmail_${SIGNATORY_2_ID_LOWER}`] = 'accountant@mail.com'
 
       when(formValidator.validate(deepEqual(form), anything())).thenReturn(null)
 


### PR DESCRIPTION
The issue here was due to the formatting of `officer_id`s.

When an error is created for a form element that utilises a camelCase name, it gets transformed into hyphen-case i.e. `onBehalfName` becomes `on-behalf-name`.

The bug here is that `officer_id`s could contain a mixture of upper and lower case letters, which was causing hyphens to be automatically inserted for example `123aBc` would become `123a-bc`. This meant that the error message link (with hyphens) could not find the corresponding form element id (camelCase).

The fix here is to lowercase to `officer_id`s, so that no camelCase instances will be identified and therefore no hyphens will be inserted.