### PR TITLE
Fix endorse-certificate page redirecting to endorse-certificate page …

### DIFF
--- a/services/infrastructure/mongo.initdb.js
+++ b/services/infrastructure/mongo.initdb.js
@@ -41,6 +41,16 @@ db.users.insert({
   "created" : { "$date" : 1420070400000 }
 })
 
+db.users.insert({
+   "_id" : "Y2VkZWVlMzhlZWFjY2M4MzQ3MU",
+   "surname" : null,
+   "locale" : "GB_en",
+   "password" : "$2a$10$6a..eerV1kSiNW3sBlcYv.VmEXyI7ABWuoo3w7zKzcdh18YKyvPbm",
+   "forename" : null,
+   "email" : "demo2@ch.gov.uk",
+   "created" : { "$date" : 1420070400000 }
+})
+
 /*
  * company_profile
  */

--- a/src/controllers/endorseCompanyClosureCertificate.controller.ts
+++ b/src/controllers/endorseCompanyClosureCertificate.controller.ts
@@ -42,7 +42,7 @@ export class EndorseCompanyClosureCertificateController extends BaseController {
       return this.renderView(errors)
     }
 
-    this.approveDissolution()
+    await this.approveDissolution()
 
     return this.redirect(REDIRECT_GATE_URI)
   }

--- a/src/controllers/redirect.controller.ts
+++ b/src/controllers/redirect.controller.ts
@@ -36,26 +36,28 @@ export class RedirectController extends BaseController {
     const dissolutionSession: DissolutionSession = this.session.getDissolutionSession(this.httpContext.request)!
     const token: string = this.session.getAccessToken(this.httpContext.request)
     const dissolution: Optional<DissolutionGetResponse> = await this.service.getDissolution(token, dissolutionSession)
+    const userEmail: string = this.session.getUserEmail(this.httpContext.request)
 
     if (!dissolution) {
       return this.redirect(SELECT_DIRECTOR_URI)
     }
 
+    const isApplicant: boolean = dissolution!.created_by === userEmail
+
     if (dissolution!.application_status === ApplicationStatus.PENDING_APPROVAL) {
-      return this.handlePendingApprovalRedirect(dissolution, dissolutionSession)
+      return this.handlePendingApprovalRedirect(dissolution, dissolutionSession, isApplicant)
     }
 
     if (dissolution!.application_status === ApplicationStatus.PENDING_PAYMENT) {
-      return this.redirect(PAYMENT_URI)
+      return this.handlePendingPaymentRedirect(isApplicant)
     }
 
     return this.redirect(ROOT_URI + '/')
   }
 
   private async handlePendingApprovalRedirect(dissolution: DissolutionGetResponse,
-                                              dissolutionSession: DissolutionSession): Promise<RedirectResult> {
+                                              dissolutionSession: DissolutionSession, isApplicant: boolean): Promise<RedirectResult> {
     const userEmail: string = this.session.getUserEmail(this.httpContext.request)
-    const isApplicant: boolean = dissolution!.created_by === userEmail
     const signingDirector: Optional<DissolutionGetDirector> = this.getUserPendingSignature(dissolution!, userEmail)
 
     if (signingDirector) {
@@ -65,6 +67,14 @@ export class RedirectController extends BaseController {
       return this.redirect(ENDORSE_COMPANY_CLOSURE_CERTIFICATE_URI)
     } else if (isApplicant) {
       return this.redirect(WAIT_FOR_OTHERS_TO_SIGN_URI)
+    } else {
+      return this.redirect(CERTIFICATE_SIGNED_URI)
+    }
+  }
+
+  private async handlePendingPaymentRedirect(isApplicant: boolean): Promise<RedirectResult> {
+    if (isApplicant) {
+      return this.redirect(PAYMENT_URI)
     } else {
       return this.redirect(CERTIFICATE_SIGNED_URI)
     }


### PR DESCRIPTION
…(missing await on api patch call)

Fix redirection logic (didn't take into account if the user is applicant or not during pending payment phase)

Add tests
Add second user to db script for testing multi-director stories