### PR TITLE
Fix URL for govukHeader

### DIFF
--- a/src/views/layout.njk
+++ b/src/views/layout.njk
@@ -23,9 +23,9 @@
 {% block header %}
   {{
     govukHeader({
-      homepageUrl: paths.ROOT_URI,
+      homepageUrl: Paths.ROOT_URI + '/',
       serviceName: serviceName,
-      serviceUrl: paths.ROOT_URI,
+      serviceUrl: Paths.ROOT_URI + '/',
       containerClasses: 'govuk-width-container'
     })
   }}


### PR DESCRIPTION
# Description

Navigate to landing page when click on the service name in the header

## Checklist

- [ ] 3 Amigos
- [x] Acceptance Criteria met
- [x] Branch named {feature|hotfix|task}/{S4-*}
- [x] Commit messages are meaningful
- [x] Manually tested
- [x] All unit tests passing
- [x] WAVE accessibility testing tool ran on new or updated pages
- [x] Pulled latest master into feature branch
- [] Code reviewed
- [x] New Docker environment variables are consistent with those on the Rebel1 environment
- [ ] If your pull request depends on any other, please link them in the description

## Screenshots of new or updated views
