### PR TITLE
Amend 'wait for others to sign' and 'application signed and final confirmation' pages to be different for Company and LLPs

### DIFF
--- a/src/controllers/certificateSigned.controller.ts
+++ b/src/controllers/certificateSigned.controller.ts
@@ -1,11 +1,11 @@
-import OfficerType from 'app/models/dto/officerType.enum'
-import DissolutionSession from 'app/models/session/dissolutionSession.model'
-import SessionService from 'app/services/session/session.service'
 import { inject } from 'inversify'
 import { controller, httpGet } from 'inversify-express-utils'
 
 import BaseController from 'app/controllers/base.controller'
+import OfficerType from 'app/models/dto/officerType.enum'
+import DissolutionSession from 'app/models/session/dissolutionSession.model'
 import { CERTIFICATE_SIGNED_URI } from 'app/paths'
+import SessionService from 'app/services/session/session.service'
 import TYPES from 'app/types'
 
 interface ViewModel {

--- a/src/controllers/certificateSigned.controller.ts
+++ b/src/controllers/certificateSigned.controller.ts
@@ -1,14 +1,37 @@
+import OfficerType from 'app/models/dto/officerType.enum'
+import DissolutionSession from 'app/models/session/dissolutionSession.model'
+import SessionService from 'app/services/session/session.service'
+import { inject } from 'inversify'
 import { controller, httpGet } from 'inversify-express-utils'
 
 import BaseController from 'app/controllers/base.controller'
 import { CERTIFICATE_SIGNED_URI } from 'app/paths'
 import TYPES from 'app/types'
 
+interface ViewModel {
+  officerType: OfficerType
+}
+
 @controller(CERTIFICATE_SIGNED_URI, TYPES.SessionMiddleware, TYPES.AuthMiddleware, TYPES.CompanyAuthMiddleware)
 export class CertificateSignedController extends BaseController {
 
+  public constructor(
+    @inject(SessionService) private session: SessionService) {
+    super()
+  }
+
   @httpGet('')
   public async get(): Promise<string> {
-    return super.render('certificate-signed')
+    const session: DissolutionSession = this.session.getDissolutionSession(this.httpContext.request)!
+
+    return this.renderView(session.officerType!)
+  }
+
+  private async renderView(officerType: OfficerType): Promise<string> {
+    const viewModel: ViewModel = {
+      officerType
+    }
+
+    return super.render('certificate-signed', viewModel)
   }
 }

--- a/src/controllers/viewFinalConfirmation.controller.ts
+++ b/src/controllers/viewFinalConfirmation.controller.ts
@@ -2,12 +2,15 @@ import { inject } from 'inversify'
 import { controller, httpGet } from 'inversify-express-utils'
 
 import BaseController from 'app/controllers/base.controller'
+import OfficerType from 'app/models/dto/officerType.enum'
+import DissolutionSession from 'app/models/session/dissolutionSession.model'
 import { VIEW_FINAL_CONFIRMATION_URI } from 'app/paths'
 import SessionService from 'app/services/session/session.service'
 import TYPES from 'app/types'
 
 interface ViewModel {
-  applicationReferenceNumber: string
+  applicationReferenceNumber: string,
+  officerType: OfficerType
 }
 
 @controller(VIEW_FINAL_CONFIRMATION_URI, TYPES.SessionMiddleware, TYPES.AuthMiddleware, TYPES.CompanyAuthMiddleware)
@@ -20,8 +23,11 @@ export class ViewFinalConfirmationController extends BaseController {
 
   @httpGet('')
   public async get(): Promise<string> {
+    const session: DissolutionSession = this.sessionService.getDissolutionSession(this.httpContext.request)!
+
     const viewModel: ViewModel = {
-      applicationReferenceNumber: this.getApplicationReferenceNumber()
+      applicationReferenceNumber: this.getApplicationReferenceNumber(),
+      officerType: session.officerType!
     }
 
     return super.render('view-final-confirmation', viewModel)

--- a/src/controllers/waitForOthersToSign.controller.ts
+++ b/src/controllers/waitForOthersToSign.controller.ts
@@ -1,16 +1,37 @@
-
+import { inject } from 'inversify'
 import { controller, httpGet } from 'inversify-express-utils'
 
 import BaseController from 'app/controllers/base.controller'
+import OfficerType from 'app/models/dto/officerType.enum'
+import DissolutionSession from 'app/models/session/dissolutionSession.model'
 import { WAIT_FOR_OTHERS_TO_SIGN_URI } from 'app/paths'
+import SessionService from 'app/services/session/session.service'
 import TYPES from 'app/types'
+
+interface ViewModel {
+  officerType: OfficerType
+}
 
 @controller(WAIT_FOR_OTHERS_TO_SIGN_URI, TYPES.SessionMiddleware, TYPES.AuthMiddleware, TYPES.CompanyAuthMiddleware)
 export class WaitForOthersToSignController extends BaseController {
 
+  public constructor(
+    @inject(SessionService) private session: SessionService) {
+    super()
+  }
+
   @httpGet('')
   public async get(): Promise<string> {
+    const session: DissolutionSession = this.session.getDissolutionSession(this.httpContext.request)!
 
-    return super.render('wait-for-others-to-sign')
+    return this.renderView(session.officerType!)
+  }
+
+  private async renderView(officerType: OfficerType): Promise<string> {
+    const viewModel: ViewModel = {
+      officerType
+    }
+
+    return super.render('wait-for-others-to-sign', viewModel)
   }
 }

--- a/src/views/certificate-signed.njk
+++ b/src/views/certificate-signed.njk
@@ -19,12 +19,12 @@
     <div class="govuk-grid-row govuk-!-margin-top-4">
       <div class="govuk-grid-column-two-thirds">
 
-        <p class="govuk-body">We need to recieve signatures from all signing directors or members before the person making the application can pay for and submit it. It may take some time for others to sign.</p>
+        <p id="signatures" class="govuk-body">We need to receive signatures from all signing {{ officerType }}s before the person making the application can pay for and submit it. It may take some time for others to sign.</p>
 
         <h2 class="govuk-heading-s">What to do next</h2>
 
         <p class="govuk-body">The person making the application can download a signed PDF copy of it after it has been submitted.</p>
-        <p class="govuk-body">The directors or members must then send this to all interested parties within 7 days of submission.</p>
+        <p id="parties" class="govuk-body">The {{ officerType }}s must then send this to all interested parties within 7 days of submission.</p>
 
         {{ govukWarningText({
           text: "It is a criminal offence not to tell all interested parties that an application has been made to close the company.",

--- a/src/views/view-final-confirmation.njk
+++ b/src/views/view-final-confirmation.njk
@@ -23,8 +23,8 @@
       <h2 class="govuk-heading-m">What to do next</h2>
 
       <p class="govuk-body"><a href="{{ Paths.CERTIFICATE_DOWNLOAD_URI }}" target="_blank" class="govuk-link">Download the signed copy of the application (opens in a new tab)</a>.</p>
-      <p class="govuk-body">
-        You must inform all directors or members that the application has been submitted, including those who signed it.
+      <p id="inform" class="govuk-body">
+        You must inform all {{ officerType }}s that the application has been submitted, including those who signed it.
         They must send a copy of the application to all interested parties within 7 days.</p>
       <p class="govuk-body">Read the <a href="https://www.gov.uk/government/publications/company-strike-off-dissolution-and-restoration/strike-off-dissolution-and-restoration#how-to-apply-for-strike-off-and-who-to-tell"
                                         target="_blank" class="govuk-link">full list of parties you must tell about the company closing (opens in a new tab)</a>.</p>

--- a/src/views/wait-for-others-to-sign.njk
+++ b/src/views/wait-for-others-to-sign.njk
@@ -11,15 +11,15 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         <div class="interruption-card">
-          <h1 id="blue-interruption-card" class="govuk-heading-xl govuk-!-margin-bottom-1">The directors or members must sign the application before you can submit it</h1>
+          <h1 id="blue-interruption-card" class="govuk-heading-xl govuk-!-margin-bottom-1">The {{ officerType }}s must sign the application before you can submit it</h1>
         </div>
       </div>
     </div>
 
     <div class="govuk-grid-row govuk-!-margin-top-4">
       <div class="govuk-grid-column-two-thirds">
-        <p class="govuk-body">We will email the directors or members and ask them to sign the application.</p>
-        <p class="govuk-body">When all directors or members have signed, we will email you with instructions to pay for and submit the application.</p>
+        <p class="govuk-body">We will email the {{ officerType }}s and ask them to sign the application.</p>
+        <p class="govuk-body">When all {{ officerType }}s have signed, we will email you with instructions to pay for and submit the application.</p>
         <p class="govuk-body">You can now exit this page.</p>
       </div>
   </div>

--- a/src/views/wait-for-others-to-sign.njk
+++ b/src/views/wait-for-others-to-sign.njk
@@ -18,8 +18,8 @@
 
     <div class="govuk-grid-row govuk-!-margin-top-4">
       <div class="govuk-grid-column-two-thirds">
-        <p class="govuk-body">We will email the {{ officerType }}s and ask them to sign the application.</p>
-        <p class="govuk-body">When all {{ officerType }}s have signed, we will email you with instructions to pay for and submit the application.</p>
+        <p id="email" class="govuk-body">We will email the {{ officerType }}s and ask them to sign the application.</p>
+        <p id="signed" class="govuk-body">When all {{ officerType }}s have signed, we will email you with instructions to pay for and submit the application.</p>
         <p class="govuk-body">You can now exit this page.</p>
       </div>
   </div>

--- a/test/controllers/certificateSigned.controller.test.ts
+++ b/test/controllers/certificateSigned.controller.test.ts
@@ -3,24 +3,72 @@ import 'reflect-metadata'
 import { assert } from 'chai'
 import { OK } from 'http-status-codes'
 import request from 'supertest'
+import { anything, instance, mock, when } from 'ts-mockito'
 import { createApp } from './helpers/application.factory'
 import HtmlAssertHelper from './helpers/htmlAssert.helper'
 
 import 'app/controllers/certificateSigned.controller'
+import OfficerType from 'app/models/dto/officerType.enum'
+import DissolutionSession from 'app/models/session/dissolutionSession.model'
 import { CERTIFICATE_SIGNED_URI } from 'app/paths'
+import SessionService from 'app/services/session/session.service'
+
+import { generateDissolutionSession } from 'test/fixtures/session.fixtures'
+
+let session: SessionService
+
+const TOKEN = 'some-token'
+const COMPANY_NUMBER = '01777777'
+
+let dissolutionSession: DissolutionSession
+
+beforeEach(() => {
+  session = mock(SessionService)
+
+  when(session.getAccessToken(anything())).thenReturn(TOKEN)
+
+  dissolutionSession = generateDissolutionSession(COMPANY_NUMBER)
+})
 
 describe('CertificateSignedController', () => {
   describe('GET request', () => {
-    it('should render the CertificateSigned page', async () => {
-     const app = createApp()
+    it('should render the CertificateSigned page with director text when the company is plc', async () => {
+      dissolutionSession.officerType = OfficerType.DIRECTOR
 
-     const res = await request(app)
-      .get(CERTIFICATE_SIGNED_URI)
-      .expect(OK)
+      when(session.getDissolutionSession(anything())).thenReturn(dissolutionSession)
 
-     const htmlAssertHelper: HtmlAssertHelper = new HtmlAssertHelper(res.text)
+      const app = createApp(container => {
+        container.rebind(SessionService).toConstantValue(instance(session))
+      })
 
-     assert.isTrue(htmlAssertHelper.hasText('h1', 'Application signed'))
+      const res = await request(app)
+        .get(CERTIFICATE_SIGNED_URI)
+        .expect(OK)
+
+      const htmlAssertHelper: HtmlAssertHelper = new HtmlAssertHelper(res.text)
+
+      assert.isTrue(htmlAssertHelper.hasText('h1', 'Application signed'))
+      assert.isTrue(htmlAssertHelper.hasText('#signatures', 'We need to receive signatures from all signing directors before the person making the application can pay for and submit it. It may take some time for others to sign.'))
+      assert.isTrue(htmlAssertHelper.hasText('#parties', 'The directors must then send this to all interested parties within 7 days of submission.'))
+    })
+
+    it('should render the CertificateSigned page with member text if the company is LLP', async () => {
+      dissolutionSession.officerType = OfficerType.MEMBER
+      when(session.getDissolutionSession(anything())).thenReturn(dissolutionSession)
+
+      const app = createApp(container => {
+        container.rebind(SessionService).toConstantValue(instance(session))
+      })
+
+      const res = await request(app)
+        .get(CERTIFICATE_SIGNED_URI)
+        .expect(OK)
+
+      const htmlAssertHelper: HtmlAssertHelper = new HtmlAssertHelper(res.text)
+
+      assert.isTrue(htmlAssertHelper.hasText('h1', 'Application signed'))
+      assert.isTrue(htmlAssertHelper.hasText('#signatures', 'We need to receive signatures from all signing members before the person making the application can pay for and submit it. It may take some time for others to sign.'))
+      assert.isTrue(htmlAssertHelper.hasText('#parties', 'The members must then send this to all interested parties within 7 days of submission.'))
     })
   })
 })

--- a/test/controllers/viewFinalConfirmation.controller.test.ts
+++ b/test/controllers/viewFinalConfirmation.controller.test.ts
@@ -1,6 +1,7 @@
 import 'reflect-metadata'
 
 import { assert } from 'chai'
+import { Application } from 'express'
 import { OK } from 'http-status-codes'
 import request from 'supertest'
 import { anything, instance, mock, when } from 'ts-mockito'
@@ -9,6 +10,7 @@ import { createApp } from './helpers/application.factory'
 import HtmlAssertHelper from './helpers/htmlAssert.helper'
 
 import 'app/controllers/viewFinalConfirmation.controller'
+import OfficerType from 'app/models/dto/officerType.enum'
 import DissolutionSession from 'app/models/session/dissolutionSession.model'
 import { VIEW_FINAL_CONFIRMATION_URI } from 'app/paths'
 import SessionService from 'app/services/session/session.service'
@@ -18,21 +20,24 @@ describe('ViewFinalConfirmationController', () => {
   const APPLICATION_REFERENCE_NUMBER = 'OVFFTH'
 
   let session: SessionService
+  let dissolutionSession: DissolutionSession
+  let app: Application
 
   beforeEach(() => {
     session = mock(SessionService)
+
+    dissolutionSession = generateDissolutionSession()
+    dissolutionSession.applicationReferenceNumber = APPLICATION_REFERENCE_NUMBER
+
+    app = createApp(container => {
+      container.rebind(SessionService).toConstantValue(instance(session))
+    })
+
+    when(session.getDissolutionSession(anything())).thenReturn(dissolutionSession)
   })
 
   describe('GET request', () => {
     it('should render the ViewFinalConfirmation page with correct reference number', async () => {
-      const dissolutionSession: DissolutionSession = generateDissolutionSession()
-      dissolutionSession.applicationReferenceNumber = APPLICATION_REFERENCE_NUMBER
-
-      when(session.getDissolutionSession(anything())).thenReturn(dissolutionSession)
-
-      const app = createApp(container => {
-        container.rebind(SessionService).toConstantValue(instance(session))
-      })
 
       const res = await request(app)
         .get(VIEW_FINAL_CONFIRMATION_URI)
@@ -42,6 +47,32 @@ describe('ViewFinalConfirmationController', () => {
 
       assert.isTrue(htmlAssertHelper.hasText('h2', 'What to do next'))
       assert.isTrue(htmlAssertHelper.containsText('div.govuk-panel__body', APPLICATION_REFERENCE_NUMBER))
+    })
+
+    it('should render the ViewFinalConfirmation page with director text if the company is plc', async () => {
+      dissolutionSession.officerType = OfficerType.DIRECTOR
+
+      const res = await request(app)
+        .get(VIEW_FINAL_CONFIRMATION_URI)
+        .expect(OK)
+
+      const htmlAssertHelper: HtmlAssertHelper = new HtmlAssertHelper(res.text)
+
+      assert.isTrue(htmlAssertHelper.hasText('h2', 'What to do next'))
+      assert.isTrue(htmlAssertHelper.containsText('#inform', 'You must inform all directors that the application has been submitted, including those who signed it.'))
+    })
+
+    it('should render the ViewFinalConfirmation page with member text if the company is LLP', async () => {
+      dissolutionSession.officerType = OfficerType.MEMBER
+
+      const res = await request(app)
+        .get(VIEW_FINAL_CONFIRMATION_URI)
+        .expect(OK)
+
+      const htmlAssertHelper: HtmlAssertHelper = new HtmlAssertHelper(res.text)
+
+      assert.isTrue(htmlAssertHelper.hasText('h2', 'What to do next'))
+      assert.isTrue(htmlAssertHelper.containsText('#inform', 'You must inform all members that the application has been submitted, including those who signed it.'))
     })
   })
 })

--- a/test/controllers/waitForOthersToSign.controller.test.ts
+++ b/test/controllers/waitForOthersToSign.controller.test.ts
@@ -22,8 +22,6 @@ const COMPANY_NUMBER = '01777777'
 
 let dissolutionSession: DissolutionSession
 
-
-
 beforeEach(() => {
   session = mock(SessionService)
 
@@ -31,6 +29,7 @@ beforeEach(() => {
 
   dissolutionSession = generateDissolutionSession(COMPANY_NUMBER)
 })
+
 describe('WaitForOthersToSignController', () => {
   describe('GET request', () => {
     it('should render the WaitForOthers page with director text when company is plc', async () => {
@@ -41,13 +40,15 @@ describe('WaitForOthersToSignController', () => {
         container.rebind(SessionService).toConstantValue(instance(session))
       })
 
-     const res = await request(app)
-      .get(WAIT_FOR_OTHERS_TO_SIGN_URI)
-      .expect(OK)
+      const res = await request(app)
+        .get(WAIT_FOR_OTHERS_TO_SIGN_URI)
+        .expect(OK)
 
-     const htmlAssertHelper: HtmlAssertHelper = new HtmlAssertHelper(res.text)
+      const htmlAssertHelper: HtmlAssertHelper = new HtmlAssertHelper(res.text)
 
-     assert.isTrue(htmlAssertHelper.hasText('h1', 'The directors must sign the application before you can submit it'))
+      assert.isTrue(htmlAssertHelper.hasText('h1', 'The directors must sign the application before you can submit it'))
+      assert.isTrue(htmlAssertHelper.hasText('#email', 'We will email the directors and ask them to sign the application.'))
+      assert.isTrue(htmlAssertHelper.hasText('#signed', 'When all directors have signed, we will email you with instructions to pay for and submit the application.'))
     })
 
     it('should render the WaitForOthers page with member text when company is llp', async () => {
@@ -65,6 +66,8 @@ describe('WaitForOthersToSignController', () => {
       const htmlAssertHelper: HtmlAssertHelper = new HtmlAssertHelper(res.text)
 
       assert.isTrue(htmlAssertHelper.hasText('h1', 'The members must sign the application before you can submit it'))
+      assert.isTrue(htmlAssertHelper.hasText('#email', 'We will email the members and ask them to sign the application.'))
+      assert.isTrue(htmlAssertHelper.hasText('#signed', 'When all members have signed, we will email you with instructions to pay for and submit the application.'))
     })
   })
 })

--- a/test/controllers/waitForOthersToSign.controller.test.ts
+++ b/test/controllers/waitForOthersToSign.controller.test.ts
@@ -1,6 +1,7 @@
 import 'reflect-metadata'
 
 import { assert } from 'chai'
+import { Application } from 'express'
 import { OK } from 'http-status-codes'
 import request from 'supertest'
 import { anything, instance, mock, when } from 'ts-mockito'
@@ -17,28 +18,27 @@ import { generateDissolutionSession } from 'test/fixtures/session.fixtures'
 
 let session: SessionService
 
-const TOKEN = 'some-token'
 const COMPANY_NUMBER = '01777777'
 
+let app: Application
 let dissolutionSession: DissolutionSession
 
 beforeEach(() => {
   session = mock(SessionService)
-
-  when(session.getAccessToken(anything())).thenReturn(TOKEN)
-
   dissolutionSession = generateDissolutionSession(COMPANY_NUMBER)
+
+  when(session.getDissolutionSession(anything())).thenReturn(dissolutionSession)
+
+  app = createApp(container => {
+    container.rebind(SessionService).toConstantValue(instance(session))
+  })
+
 })
 
 describe('WaitForOthersToSignController', () => {
   describe('GET request', () => {
     it('should render the WaitForOthers page with director text when company is plc', async () => {
       dissolutionSession.officerType = OfficerType.DIRECTOR
-      when(session.getDissolutionSession(anything())).thenReturn(dissolutionSession)
-
-      const app = createApp(container => {
-        container.rebind(SessionService).toConstantValue(instance(session))
-      })
 
       const res = await request(app)
         .get(WAIT_FOR_OTHERS_TO_SIGN_URI)
@@ -53,11 +53,6 @@ describe('WaitForOthersToSignController', () => {
 
     it('should render the WaitForOthers page with member text when company is llp', async () => {
       dissolutionSession.officerType = OfficerType.MEMBER
-      when(session.getDissolutionSession(anything())).thenReturn(dissolutionSession)
-
-      const app = createApp(container => {
-        container.rebind(SessionService).toConstantValue(instance(session))
-      })
 
       const res = await request(app)
         .get(WAIT_FOR_OTHERS_TO_SIGN_URI)

--- a/test/controllers/waitForOthersToSign.controller.test.ts
+++ b/test/controllers/waitForOthersToSign.controller.test.ts
@@ -3,16 +3,43 @@ import 'reflect-metadata'
 import { assert } from 'chai'
 import { OK } from 'http-status-codes'
 import request from 'supertest'
+import { anything, instance, mock, when } from 'ts-mockito'
 import { createApp } from './helpers/application.factory'
 import HtmlAssertHelper from './helpers/htmlAssert.helper'
 
 import 'app/controllers/waitForOthersToSign.controller'
+import OfficerType from 'app/models/dto/officerType.enum'
+import DissolutionSession from 'app/models/session/dissolutionSession.model'
 import { WAIT_FOR_OTHERS_TO_SIGN_URI } from 'app/paths'
+import SessionService from 'app/services/session/session.service'
 
+import { generateDissolutionSession } from 'test/fixtures/session.fixtures'
+
+let session: SessionService
+
+const TOKEN = 'some-token'
+const COMPANY_NUMBER = '01777777'
+
+let dissolutionSession: DissolutionSession
+
+
+
+beforeEach(() => {
+  session = mock(SessionService)
+
+  when(session.getAccessToken(anything())).thenReturn(TOKEN)
+
+  dissolutionSession = generateDissolutionSession(COMPANY_NUMBER)
+})
 describe('WaitForOthersToSignController', () => {
   describe('GET request', () => {
-    it('should render the WaitForOthers page', async () => {
-     const app = createApp()
+    it('should render the WaitForOthers page with director text when company is plc', async () => {
+      dissolutionSession.officerType = OfficerType.DIRECTOR
+      when(session.getDissolutionSession(anything())).thenReturn(dissolutionSession)
+
+      const app = createApp(container => {
+        container.rebind(SessionService).toConstantValue(instance(session))
+      })
 
      const res = await request(app)
       .get(WAIT_FOR_OTHERS_TO_SIGN_URI)
@@ -20,7 +47,24 @@ describe('WaitForOthersToSignController', () => {
 
      const htmlAssertHelper: HtmlAssertHelper = new HtmlAssertHelper(res.text)
 
-     assert.isTrue(htmlAssertHelper.hasText('h1', 'The directors or members must sign the application before you can submit it'))
+     assert.isTrue(htmlAssertHelper.hasText('h1', 'The directors must sign the application before you can submit it'))
+    })
+
+    it('should render the WaitForOthers page with member text when company is llp', async () => {
+      dissolutionSession.officerType = OfficerType.MEMBER
+      when(session.getDissolutionSession(anything())).thenReturn(dissolutionSession)
+
+      const app = createApp(container => {
+        container.rebind(SessionService).toConstantValue(instance(session))
+      })
+
+      const res = await request(app)
+        .get(WAIT_FOR_OTHERS_TO_SIGN_URI)
+        .expect(OK)
+
+      const htmlAssertHelper: HtmlAssertHelper = new HtmlAssertHelper(res.text)
+
+      assert.isTrue(htmlAssertHelper.hasText('h1', 'The members must sign the application before you can submit it'))
     })
   })
 })


### PR DESCRIPTION
## Description

Amend 'wait for others to sign' and 'application signed and final confirmation' pages to be different for Company and LLPs

chs-notification-api - https://companieshouse.atlassian.net/browse/S4-220
dissolution-web - https://github.com/companieshouse/dissolution-web/pull/93
dissolution-api - https://github.com/companieshouse/dissolution-api/pull/61

## Coding Standards

Code Style Guide: https://github.com/companieshouse/dissolution-web/wiki/Code-Style-Guide

## Checklist

- [x] 3 Amigos
- [x] Acceptance Criteria met
- [x] Branch named {feature|hotfix|task}/{S4-*}
- [x] Commit messages are meaningful
- [x] Manually tested
- [x] All unit tests passing
- [x] WAVE accessibility testing tool ran on new or updated pages
- [x] Pulled latest master into feature branch
- [x] Code reviewed
- [x] New Docker environment variables are consistent with those on the Rebel1 environment
- [x] If your pull request depends on any other, please link them in the description

## Screenshots of new or updated views
<img width="628" alt="Screenshot 2020-09-11 at 09 36 38" src="https://user-images.githubusercontent.com/20680998/92884803-7c497900-f412-11ea-9759-13d78e509d8e.png">
<img width="678" alt="Screenshot 2020-09-11 at 09 36 03" src="https://user-images.githubusercontent.com/20680998/92884808-7e133c80-f412-11ea-86dc-fea67d5013a7.png">
<img width="785" alt="Screenshot 2020-09-11 at 09 35 34" src="https://user-images.githubusercontent.com/20680998/92884816-7eabd300-f412-11ea-8db4-d9e631ab02d4.png">
<img width="707" alt="Screenshot 2020-09-11 at 09 34 42" src="https://user-images.githubusercontent.com/20680998/92884820-7fdd0000-f412-11ea-80fb-68e2bdaa5ae0.png">
<img width="1143" alt="Screenshot 2020-09-11 at 09 33 54" src="https://user-images.githubusercontent.com/20680998/92884825-810e2d00-f412-11ea-8c0b-cf35da199e24.png">
<img width="1220" alt="Screenshot 2020-09-11 at 09 32 21" src="https://user-images.githubusercontent.com/20680998/92884829-823f5a00-f412-11ea-879b-37d7e056c88e.png">
