### PR TITLE
feature/S4-98: Add signout banner on all internal service pages when logged in.

### DIFF
--- a/src/controllers/certificateDownload.controller.ts
+++ b/src/controllers/certificateDownload.controller.ts
@@ -9,10 +9,7 @@ import DissolutionService from 'app/services/dissolution/dissolution.service'
 import SessionService from 'app/services/session/session.service'
 import TYPES from 'app/types'
 
-@controller(
-  CERTIFICATE_DOWNLOAD_URI,
-  TYPES.SessionMiddleware, TYPES.AuthMiddleware, TYPES.CompanyAuthMiddleware, TYPES.SignOutUserBannerMiddleware
-)
+@controller(CERTIFICATE_DOWNLOAD_URI, TYPES.AuthMiddleware, TYPES.CompanyAuthMiddleware)
 export class CertificateDownloadController extends BaseController {
 
   public constructor(

--- a/src/controllers/certificateDownload.controller.ts
+++ b/src/controllers/certificateDownload.controller.ts
@@ -9,7 +9,10 @@ import DissolutionService from 'app/services/dissolution/dissolution.service'
 import SessionService from 'app/services/session/session.service'
 import TYPES from 'app/types'
 
-@controller(CERTIFICATE_DOWNLOAD_URI, TYPES.SessionMiddleware, TYPES.AuthMiddleware, TYPES.CompanyAuthMiddleware)
+@controller(
+  CERTIFICATE_DOWNLOAD_URI,
+  TYPES.SessionMiddleware, TYPES.AuthMiddleware, TYPES.CompanyAuthMiddleware, TYPES.SignOutUserBannerMiddleware
+)
 export class CertificateDownloadController extends BaseController {
 
   public constructor(

--- a/src/controllers/certificateSigned.controller.ts
+++ b/src/controllers/certificateSigned.controller.ts
@@ -12,7 +12,10 @@ interface ViewModel {
   officerType: OfficerType
 }
 
-@controller(CERTIFICATE_SIGNED_URI, TYPES.SessionMiddleware, TYPES.AuthMiddleware, TYPES.CompanyAuthMiddleware)
+@controller(
+  CERTIFICATE_SIGNED_URI,
+  TYPES.SessionMiddleware, TYPES.AuthMiddleware, TYPES.CompanyAuthMiddleware, TYPES.SignOutUserBannerMiddleware
+)
 export class CertificateSignedController extends BaseController {
 
   public constructor(

--- a/src/controllers/certificateSigned.controller.ts
+++ b/src/controllers/certificateSigned.controller.ts
@@ -12,10 +12,7 @@ interface ViewModel {
   officerType: OfficerType
 }
 
-@controller(
-  CERTIFICATE_SIGNED_URI,
-  TYPES.SessionMiddleware, TYPES.AuthMiddleware, TYPES.CompanyAuthMiddleware, TYPES.SignOutUserBannerMiddleware
-)
+@controller(CERTIFICATE_SIGNED_URI, TYPES.AuthMiddleware, TYPES.CompanyAuthMiddleware)
 export class CertificateSignedController extends BaseController {
 
   public constructor(

--- a/src/controllers/checkYourAnswers.controller.ts
+++ b/src/controllers/checkYourAnswers.controller.ts
@@ -16,10 +16,7 @@ interface ViewModel {
   directors?: CheckYourAnswersDirector[]
 }
 
-@controller(
-  CHECK_YOUR_ANSWERS_URI,
-  TYPES.SessionMiddleware, TYPES.AuthMiddleware, TYPES.CompanyAuthMiddleware, TYPES.SignOutUserBannerMiddleware
-)
+@controller(CHECK_YOUR_ANSWERS_URI, TYPES.AuthMiddleware, TYPES.CompanyAuthMiddleware)
 export class CheckYourAnswersController extends BaseController {
 
   public constructor(

--- a/src/controllers/checkYourAnswers.controller.ts
+++ b/src/controllers/checkYourAnswers.controller.ts
@@ -16,7 +16,10 @@ interface ViewModel {
   directors?: CheckYourAnswersDirector[]
 }
 
-@controller(CHECK_YOUR_ANSWERS_URI, TYPES.SessionMiddleware, TYPES.AuthMiddleware, TYPES.CompanyAuthMiddleware)
+@controller(
+  CHECK_YOUR_ANSWERS_URI,
+  TYPES.SessionMiddleware, TYPES.AuthMiddleware, TYPES.CompanyAuthMiddleware, TYPES.SignOutUserBannerMiddleware
+)
 export class CheckYourAnswersController extends BaseController {
 
   public constructor(

--- a/src/controllers/defineSignatoryInfo.controller.ts
+++ b/src/controllers/defineSignatoryInfo.controller.ts
@@ -25,7 +25,10 @@ interface ViewModel {
   errors?: Optional<ValidationErrors>
 }
 
-@controller(DEFINE_SIGNATORY_INFO_URI, TYPES.SessionMiddleware, TYPES.AuthMiddleware, TYPES.CompanyAuthMiddleware)
+@controller(
+  DEFINE_SIGNATORY_INFO_URI,
+  TYPES.SessionMiddleware, TYPES.AuthMiddleware, TYPES.CompanyAuthMiddleware, TYPES.SignOutUserBannerMiddleware
+)
 export class DefineSignatoryInfoController extends BaseController {
 
   public constructor(

--- a/src/controllers/defineSignatoryInfo.controller.ts
+++ b/src/controllers/defineSignatoryInfo.controller.ts
@@ -25,10 +25,7 @@ interface ViewModel {
   errors?: Optional<ValidationErrors>
 }
 
-@controller(
-  DEFINE_SIGNATORY_INFO_URI,
-  TYPES.SessionMiddleware, TYPES.AuthMiddleware, TYPES.CompanyAuthMiddleware, TYPES.SignOutUserBannerMiddleware
-)
+@controller(DEFINE_SIGNATORY_INFO_URI, TYPES.AuthMiddleware, TYPES.CompanyAuthMiddleware)
 export class DefineSignatoryInfoController extends BaseController {
 
   public constructor(

--- a/src/controllers/endorseCompanyClosureCertificate.controller.ts
+++ b/src/controllers/endorseCompanyClosureCertificate.controller.ts
@@ -21,10 +21,7 @@ interface ViewModel {
   errors?: ValidationErrors
 }
 
-@controller(
-  ENDORSE_COMPANY_CLOSURE_CERTIFICATE_URI,
-  TYPES.SessionMiddleware, TYPES.AuthMiddleware, TYPES.CompanyAuthMiddleware, TYPES.SignOutUserBannerMiddleware
-)
+@controller(ENDORSE_COMPANY_CLOSURE_CERTIFICATE_URI, TYPES.AuthMiddleware, TYPES.CompanyAuthMiddleware)
 export class EndorseCompanyClosureCertificateController extends BaseController {
 
   public constructor(@inject(SessionService) private session: SessionService,

--- a/src/controllers/endorseCompanyClosureCertificate.controller.ts
+++ b/src/controllers/endorseCompanyClosureCertificate.controller.ts
@@ -21,7 +21,10 @@ interface ViewModel {
   errors?: ValidationErrors
 }
 
-@controller(ENDORSE_COMPANY_CLOSURE_CERTIFICATE_URI, TYPES.SessionMiddleware, TYPES.AuthMiddleware, TYPES.CompanyAuthMiddleware)
+@controller(
+  ENDORSE_COMPANY_CLOSURE_CERTIFICATE_URI,
+  TYPES.SessionMiddleware, TYPES.AuthMiddleware, TYPES.CompanyAuthMiddleware, TYPES.SignOutUserBannerMiddleware
+)
 export class EndorseCompanyClosureCertificateController extends BaseController {
 
   public constructor(@inject(SessionService) private session: SessionService,

--- a/src/controllers/notSelectedSignatory.controller.ts
+++ b/src/controllers/notSelectedSignatory.controller.ts
@@ -4,7 +4,10 @@ import BaseController from 'app/controllers/base.controller'
 import { NOT_SELECTED_SIGNATORY } from 'app/paths'
 import TYPES from 'app/types'
 
-@controller(NOT_SELECTED_SIGNATORY, TYPES.SessionMiddleware, TYPES.AuthMiddleware, TYPES.CompanyAuthMiddleware)
+@controller(
+  NOT_SELECTED_SIGNATORY,
+  TYPES.SessionMiddleware, TYPES.AuthMiddleware, TYPES.CompanyAuthMiddleware, TYPES.SignOutUserBannerMiddleware
+)
 export class NotSelectedSignatoryController extends BaseController {
 
   @httpGet('')

--- a/src/controllers/notSelectedSignatory.controller.ts
+++ b/src/controllers/notSelectedSignatory.controller.ts
@@ -4,10 +4,7 @@ import BaseController from 'app/controllers/base.controller'
 import { NOT_SELECTED_SIGNATORY } from 'app/paths'
 import TYPES from 'app/types'
 
-@controller(
-  NOT_SELECTED_SIGNATORY,
-  TYPES.SessionMiddleware, TYPES.AuthMiddleware, TYPES.CompanyAuthMiddleware, TYPES.SignOutUserBannerMiddleware
-)
+@controller(NOT_SELECTED_SIGNATORY, TYPES.AuthMiddleware, TYPES.CompanyAuthMiddleware)
 export class NotSelectedSignatoryController extends BaseController {
 
   @httpGet('')

--- a/src/controllers/payment.controller.ts
+++ b/src/controllers/payment.controller.ts
@@ -10,7 +10,7 @@ import PaymentService from 'app/services/payment/payment.service'
 import SessionService from 'app/services/session/session.service'
 import TYPES from 'app/types'
 
-@controller(PAYMENT_URI, TYPES.SessionMiddleware, TYPES.AuthMiddleware, TYPES.CompanyAuthMiddleware)
+@controller(PAYMENT_URI, TYPES.AuthMiddleware, TYPES.CompanyAuthMiddleware)
 export class PaymentController extends BaseController {
 
   public constructor(

--- a/src/controllers/redirect.controller.ts
+++ b/src/controllers/redirect.controller.ts
@@ -24,7 +24,10 @@ import DissolutionService from 'app/services/dissolution/dissolution.service'
 import SessionService from 'app/services/session/session.service'
 import TYPES from 'app/types'
 
-@controller(REDIRECT_GATE_URI, TYPES.SessionMiddleware, TYPES.AuthMiddleware, TYPES.CompanyAuthMiddleware)
+@controller(
+  REDIRECT_GATE_URI,
+  TYPES.SessionMiddleware, TYPES.AuthMiddleware, TYPES.CompanyAuthMiddleware
+)
 export class RedirectController extends BaseController {
 
   public constructor(

--- a/src/controllers/redirect.controller.ts
+++ b/src/controllers/redirect.controller.ts
@@ -24,10 +24,7 @@ import DissolutionService from 'app/services/dissolution/dissolution.service'
 import SessionService from 'app/services/session/session.service'
 import TYPES from 'app/types'
 
-@controller(
-  REDIRECT_GATE_URI,
-  TYPES.SessionMiddleware, TYPES.AuthMiddleware, TYPES.CompanyAuthMiddleware
-)
+@controller(REDIRECT_GATE_URI, TYPES.AuthMiddleware, TYPES.CompanyAuthMiddleware)
 export class RedirectController extends BaseController {
 
   public constructor(

--- a/src/controllers/searchCompany.controller.ts
+++ b/src/controllers/searchCompany.controller.ts
@@ -21,10 +21,7 @@ interface ViewModel {
   errors?: ValidationErrors
 }
 
-@controller(
-  SEARCH_COMPANY_URI,
-  TYPES.SessionMiddleware, TYPES.AuthMiddleware, TYPES.SignOutUserBannerMiddleware
-)
+@controller(SEARCH_COMPANY_URI, TYPES.AuthMiddleware)
 export class SearchCompanyController extends BaseController {
 
   public constructor(

--- a/src/controllers/searchCompany.controller.ts
+++ b/src/controllers/searchCompany.controller.ts
@@ -21,13 +21,17 @@ interface ViewModel {
   errors?: ValidationErrors
 }
 
-@controller(SEARCH_COMPANY_URI, TYPES.SessionMiddleware, TYPES.AuthMiddleware)
+@controller(
+  SEARCH_COMPANY_URI,
+  TYPES.SessionMiddleware, TYPES.AuthMiddleware, TYPES.SignOutUserBannerMiddleware
+)
 export class SearchCompanyController extends BaseController {
 
   public constructor(
     @inject(FormValidator) private validator: FormValidator,
     @inject(CompanyService) private companyService: CompanyService,
-    @inject(SessionService) private session: SessionService) {
+    @inject(SessionService) private sessionService: SessionService
+  ) {
     super()
   }
 
@@ -63,15 +67,15 @@ export class SearchCompanyController extends BaseController {
   }
 
   private async doesCompanyExist(companyNumber: string): Promise<boolean> {
-    const token: string = this.session.getAccessToken(this.httpContext.request)
+    const token: string = this.sessionService.getAccessToken(this.httpContext.request)
     return this.companyService.doesCompanyExist(token, companyNumber)
   }
 
   private updateSession(body: SearchCompanyFormModel): void {
     const updatedSession: DissolutionSession = {
-      ...this.session.getDissolutionSession(this.httpContext.request),
+      ...this.sessionService.getDissolutionSession(this.httpContext.request),
       companyNumber: body.companyNumber!
     }
-    this.session.setDissolutionSession(this.httpContext.request, updatedSession)
+    this.sessionService.setDissolutionSession(this.httpContext.request, updatedSession)
   }
 }

--- a/src/controllers/selectDirector.controller.ts
+++ b/src/controllers/selectDirector.controller.ts
@@ -26,10 +26,7 @@ interface ViewModel {
   errors?: Optional<ValidationErrors>
 }
 
-@controller(
-  SELECT_DIRECTOR_URI,
-  TYPES.SessionMiddleware, TYPES.AuthMiddleware, TYPES.CompanyAuthMiddleware, TYPES.SignOutUserBannerMiddleware
-)
+@controller(SELECT_DIRECTOR_URI, TYPES.AuthMiddleware, TYPES.CompanyAuthMiddleware)
 export class SelectDirectorController extends BaseController {
 
   public constructor(

--- a/src/controllers/selectDirector.controller.ts
+++ b/src/controllers/selectDirector.controller.ts
@@ -26,7 +26,10 @@ interface ViewModel {
   errors?: Optional<ValidationErrors>
 }
 
-@controller(SELECT_DIRECTOR_URI, TYPES.SessionMiddleware, TYPES.AuthMiddleware, TYPES.CompanyAuthMiddleware)
+@controller(
+  SELECT_DIRECTOR_URI,
+  TYPES.SessionMiddleware, TYPES.AuthMiddleware, TYPES.CompanyAuthMiddleware, TYPES.SignOutUserBannerMiddleware
+)
 export class SelectDirectorController extends BaseController {
 
   public constructor(

--- a/src/controllers/selectSignatories.controller.ts
+++ b/src/controllers/selectSignatories.controller.ts
@@ -27,7 +27,10 @@ interface ViewModel {
   errors?: Optional<ValidationErrors>
 }
 
-@controller(SELECT_SIGNATORIES_URI, TYPES.SessionMiddleware, TYPES.AuthMiddleware, TYPES.CompanyAuthMiddleware)
+@controller(
+  SELECT_SIGNATORIES_URI,
+  TYPES.SessionMiddleware, TYPES.AuthMiddleware, TYPES.CompanyAuthMiddleware, TYPES.SignOutUserBannerMiddleware
+)
 export class SelectSignatoriesController extends BaseController {
 
   public constructor(

--- a/src/controllers/selectSignatories.controller.ts
+++ b/src/controllers/selectSignatories.controller.ts
@@ -27,10 +27,7 @@ interface ViewModel {
   errors?: Optional<ValidationErrors>
 }
 
-@controller(
-  SELECT_SIGNATORIES_URI,
-  TYPES.SessionMiddleware, TYPES.AuthMiddleware, TYPES.CompanyAuthMiddleware, TYPES.SignOutUserBannerMiddleware
-)
+@controller(SELECT_SIGNATORIES_URI, TYPES.AuthMiddleware, TYPES.CompanyAuthMiddleware)
 export class SelectSignatoriesController extends BaseController {
 
   public constructor(

--- a/src/controllers/viewCompanyInformation.controller.ts
+++ b/src/controllers/viewCompanyInformation.controller.ts
@@ -15,10 +15,7 @@ interface ViewModel {
   company: CompanyDetails
 }
 
-@controller(
-  VIEW_COMPANY_INFORMATION_URI,
-  TYPES.SessionMiddleware, TYPES.AuthMiddleware, TYPES.SignOutUserBannerMiddleware
-)
+@controller(VIEW_COMPANY_INFORMATION_URI, TYPES.AuthMiddleware)
 export class ViewCompanyInformationController extends BaseController {
 
   public constructor(

--- a/src/controllers/viewCompanyInformation.controller.ts
+++ b/src/controllers/viewCompanyInformation.controller.ts
@@ -15,7 +15,10 @@ interface ViewModel {
   company: CompanyDetails
 }
 
-@controller(VIEW_COMPANY_INFORMATION_URI, TYPES.SessionMiddleware, TYPES.AuthMiddleware)
+@controller(
+  VIEW_COMPANY_INFORMATION_URI,
+  TYPES.SessionMiddleware, TYPES.AuthMiddleware, TYPES.SignOutUserBannerMiddleware
+)
 export class ViewCompanyInformationController extends BaseController {
 
   public constructor(

--- a/src/controllers/viewFinalConfirmation.controller.ts
+++ b/src/controllers/viewFinalConfirmation.controller.ts
@@ -13,10 +13,7 @@ interface ViewModel {
   officerType: OfficerType
 }
 
-@controller(
-  VIEW_FINAL_CONFIRMATION_URI,
-  TYPES.SessionMiddleware, TYPES.AuthMiddleware, TYPES.CompanyAuthMiddleware, TYPES.SignOutUserBannerMiddleware
-)
+@controller(VIEW_FINAL_CONFIRMATION_URI, TYPES.AuthMiddleware, TYPES.CompanyAuthMiddleware)
 export class ViewFinalConfirmationController extends BaseController {
 
   public constructor(

--- a/src/controllers/viewFinalConfirmation.controller.ts
+++ b/src/controllers/viewFinalConfirmation.controller.ts
@@ -13,7 +13,10 @@ interface ViewModel {
   officerType: OfficerType
 }
 
-@controller(VIEW_FINAL_CONFIRMATION_URI, TYPES.SessionMiddleware, TYPES.AuthMiddleware, TYPES.CompanyAuthMiddleware)
+@controller(
+  VIEW_FINAL_CONFIRMATION_URI,
+  TYPES.SessionMiddleware, TYPES.AuthMiddleware, TYPES.CompanyAuthMiddleware, TYPES.SignOutUserBannerMiddleware
+)
 export class ViewFinalConfirmationController extends BaseController {
 
   public constructor(

--- a/src/controllers/waitForOthersToSign.controller.ts
+++ b/src/controllers/waitForOthersToSign.controller.ts
@@ -12,10 +12,7 @@ interface ViewModel {
   officerType: OfficerType
 }
 
-@controller(
-  WAIT_FOR_OTHERS_TO_SIGN_URI,
-  TYPES.SessionMiddleware, TYPES.AuthMiddleware, TYPES.CompanyAuthMiddleware, TYPES.SignOutUserBannerMiddleware
-)
+@controller(WAIT_FOR_OTHERS_TO_SIGN_URI, TYPES.AuthMiddleware, TYPES.CompanyAuthMiddleware)
 export class WaitForOthersToSignController extends BaseController {
 
   public constructor(

--- a/src/controllers/waitForOthersToSign.controller.ts
+++ b/src/controllers/waitForOthersToSign.controller.ts
@@ -12,7 +12,10 @@ interface ViewModel {
   officerType: OfficerType
 }
 
-@controller(WAIT_FOR_OTHERS_TO_SIGN_URI, TYPES.SessionMiddleware, TYPES.AuthMiddleware, TYPES.CompanyAuthMiddleware)
+@controller(
+  WAIT_FOR_OTHERS_TO_SIGN_URI,
+  TYPES.SessionMiddleware, TYPES.AuthMiddleware, TYPES.CompanyAuthMiddleware, TYPES.SignOutUserBannerMiddleware
+)
 export class WaitForOthersToSignController extends BaseController {
 
   public constructor(

--- a/src/inversify.config.ts
+++ b/src/inversify.config.ts
@@ -9,7 +9,7 @@ import { Container } from 'inversify'
 import { buildProviderModule } from 'inversify-binding-decorators'
 import IORedis from 'ioredis'
 import { authMiddleware as commonAuthMiddleware } from 'web-security-node'
-import SignOutUserBannerMiddleware from './middleware/signOutUserBanner.middleware'
+import SaveUserEmailToLocals from './middleware/saveUserEmailToLocals.middleware'
 import PiwikConfig from './models/piwikConfig'
 
 import { APP_NAME } from 'app/constants/app.const'
@@ -77,8 +77,8 @@ export function initContainer(): Container {
     CompanyAuthMiddleware(authConfig, new JwtEncryptionService(authConfig), sessionService, logger)
   )
 
-  container.bind(TYPES.SignOutUserBannerMiddleware).toConstantValue(
-    SignOutUserBannerMiddleware(sessionService)
+  container.bind(TYPES.SaveUserEmailToLocals).toConstantValue(
+    SaveUserEmailToLocals(sessionService)
   )
 
   container.load(buildProviderModule())
@@ -87,4 +87,3 @@ export function initContainer(): Container {
 }
 
 export default initContainer
-

--- a/src/middleware/auth.middleware.ts
+++ b/src/middleware/auth.middleware.ts
@@ -4,8 +4,10 @@ import { AuthOptions } from 'web-security-node'
 import { SEARCH_COMPANY_URI } from 'app/paths'
 import UriFactory from 'app/utils/uri.factory'
 
-export default function AuthMiddleware(accountWebUrl: string, uriFactory: UriFactory,
-                                       commonAuthMiddleware: (opts: AuthOptions) => RequestHandler): RequestHandler {
+export default function AuthMiddleware(
+  accountWebUrl: string, uriFactory: UriFactory,
+  commonAuthMiddleware: (opts: AuthOptions) => RequestHandler
+): RequestHandler {
   return (req: Request, res: Response, next: NextFunction) => {
     const authOptions: AuthOptions = {
       returnUrl: uriFactory.createAbsoluteUri(req, SEARCH_COMPANY_URI),

--- a/src/middleware/auth.middleware.ts
+++ b/src/middleware/auth.middleware.ts
@@ -5,8 +5,7 @@ import { SEARCH_COMPANY_URI } from 'app/paths'
 import UriFactory from 'app/utils/uri.factory'
 
 export default function AuthMiddleware(
-  accountWebUrl: string, uriFactory: UriFactory,
-  commonAuthMiddleware: (opts: AuthOptions) => RequestHandler
+  accountWebUrl: string, uriFactory: UriFactory, commonAuthMiddleware: (opts: AuthOptions) => RequestHandler
 ): RequestHandler {
   return (req: Request, res: Response, next: NextFunction) => {
     const authOptions: AuthOptions = {

--- a/src/middleware/companyAuth.middleware.ts
+++ b/src/middleware/companyAuth.middleware.ts
@@ -11,10 +11,10 @@ import SessionService from 'app/services/session/session.service'
 
 const OATH_SCOPE_PREFIX = 'https://api.companieshouse.gov.uk/company/'
 
-export default function CompanyAuthMiddleware(authConfig: AuthConfig,
-                                              encryptionService: JwtEncryptionService,
-                                              sessionService: SessionService,
-                                              logger: ApplicationLogger): RequestHandler {
+export default function CompanyAuthMiddleware(
+  authConfig: AuthConfig, encryptionService: JwtEncryptionService,
+  sessionService: SessionService, logger: ApplicationLogger
+): RequestHandler {
   return async (req: Request, res: Response, next: NextFunction) => {
     const dissolutionSession: Optional<DissolutionSession> = sessionService.getDissolutionSession(req)
 

--- a/src/middleware/companyAuth.middleware.ts
+++ b/src/middleware/companyAuth.middleware.ts
@@ -12,8 +12,7 @@ import SessionService from 'app/services/session/session.service'
 const OATH_SCOPE_PREFIX = 'https://api.companieshouse.gov.uk/company/'
 
 export default function CompanyAuthMiddleware(
-  authConfig: AuthConfig, encryptionService: JwtEncryptionService,
-  sessionService: SessionService, logger: ApplicationLogger
+  authConfig: AuthConfig, encryptionService: JwtEncryptionService, sessionService: SessionService, logger: ApplicationLogger
 ): RequestHandler {
   return async (req: Request, res: Response, next: NextFunction) => {
     const dissolutionSession: Optional<DissolutionSession> = sessionService.getDissolutionSession(req)

--- a/src/middleware/saveUserEmailToLocals.middleware.ts
+++ b/src/middleware/saveUserEmailToLocals.middleware.ts
@@ -2,11 +2,11 @@ import { NextFunction, Request, RequestHandler, Response } from 'express'
 
 import SessionService from 'app/services/session/session.service'
 
-export default function SignOutUserBannerMiddleware(sessionService: SessionService): RequestHandler {
+export default function SaveUserEmailToLocals(sessionService: SessionService): RequestHandler {
   return (req: Request, res: Response, next: NextFunction) => {
-    const userEmail: string = sessionService.getUserEmail(req)
-
-    res.locals.userEmail = userEmail
+    if (req.session) {
+      res.locals.userEmail = sessionService.getUserEmail(req)
+    }
 
     return next()
   }

--- a/src/middleware/serverMiddlewareLoader.middleware.ts
+++ b/src/middleware/serverMiddlewareLoader.middleware.ts
@@ -4,33 +4,39 @@ import bodyParser from 'body-parser'
 import { createLoggerMiddleware } from 'ch-logging'
 import ApplicationLogger from 'ch-logging/lib/ApplicationLogger'
 import cookieParser from 'cookie-parser'
-import * as express from 'express'
+import { Application, NextFunction, Request, RequestHandler, Response } from 'express'
 import { INTERNAL_SERVER_ERROR } from 'http-status-codes'
 import { inject } from 'inversify'
 import { provide } from 'inversify-binding-decorators'
 import NunjucksLoader from './nunjucksLoader.middleware'
 
 import { APP_NAME } from 'app/constants/app.const'
+import TYPES from 'app/types'
 
 @provide(ServerMiddlewareLoader)
 export default class ServerMiddlewareLoader {
 
   public constructor(
     @inject(NunjucksLoader) private nunjucks: NunjucksLoader,
-    @inject(ApplicationLogger) private logger: ApplicationLogger
+    @inject(ApplicationLogger) private logger: ApplicationLogger,
+    @inject(TYPES.SessionMiddleware) private sessionMiddleware: RequestHandler,
+    @inject(TYPES.SaveUserEmailToLocals) private saveUserEmailToLocals: RequestHandler
   ) {}
 
-  public loadServerMiddleware(app: express.Application, directory: string): void {
+  public loadServerMiddleware(app: Application, directory: string): void {
     app.use(bodyParser.json())
     app.use(bodyParser.urlencoded({ extended: true }))
     app.use(cookieParser())
     app.use(createLoggerMiddleware(APP_NAME))
 
+    app.use(this.sessionMiddleware)
+    app.use(this.saveUserEmailToLocals)
+
     this.nunjucks.configureNunjucks(app, directory)
   }
 
-  public configureErrorHandling(app: express.Application): void {
-    app.use((err: any, _: express.Request, res: express.Response, _2: express.NextFunction) => {
+  public configureErrorHandling(app: Application): void {
+    app.use((err: any, _: Request, res: Response, _2: NextFunction) => {
       this.logger.error(`${err.constructor.name} - ${err.message}`)
 
       return res.status(err.statusCode || INTERNAL_SERVER_ERROR).render('error')

--- a/src/middleware/serverMiddlewareLoader.middleware.ts
+++ b/src/middleware/serverMiddlewareLoader.middleware.ts
@@ -17,7 +17,8 @@ export default class ServerMiddlewareLoader {
 
   public constructor(
     @inject(NunjucksLoader) private nunjucks: NunjucksLoader,
-    @inject(ApplicationLogger) private logger: ApplicationLogger) {}
+    @inject(ApplicationLogger) private logger: ApplicationLogger
+  ) {}
 
   public loadServerMiddleware(app: express.Application, directory: string): void {
     app.use(bodyParser.json())

--- a/src/middleware/signOutUserBanner.middleware.ts
+++ b/src/middleware/signOutUserBanner.middleware.ts
@@ -1,0 +1,13 @@
+import { NextFunction, Request, RequestHandler, Response } from 'express'
+
+import SessionService from 'app/services/session/session.service'
+
+export default function SignOutUserBannerMiddleware(sessionService: SessionService): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction) => {
+    const userEmail: string = sessionService.getUserEmail(req)
+
+    res.locals.userEmail = userEmail
+
+    return next()
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,7 +10,7 @@ const TYPES = {
   SessionMiddleware: 'SessionMiddleware',
   AuthMiddleware: 'AuthMiddleware',
   CompanyAuthMiddleware: 'CompanyAuthMiddleware',
-  SignOutUserBannerMiddleware: 'SignOutUserBannerMiddleware',
+  SaveUserEmailToLocals: 'SaveUserEmailToLocals',
   AxiosInstance: 'AxiosInstance',
   S3: 'S3'
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,6 +10,7 @@ const TYPES = {
   SessionMiddleware: 'SessionMiddleware',
   AuthMiddleware: 'AuthMiddleware',
   CompanyAuthMiddleware: 'CompanyAuthMiddleware',
+  SignOutUserBannerMiddleware: 'SignOutUserBannerMiddleware',
   AxiosInstance: 'AxiosInstance',
   S3: 'S3'
 }

--- a/src/views/components/sign-out-user-banner.njk
+++ b/src/views/components/sign-out-user-banner.njk
@@ -1,0 +1,12 @@
+{% if userEmail %}
+  <div class="govuk-section-break--visible">
+    <div class="sign-out-user-banner">
+      <span id="signed_in_user_email" class="sign-out-user-banner__email">
+        {{ userEmail }}
+      </span>
+      <span>
+        <a id="sign_out" href="/signout">Sign out</a>
+      </span>
+    </div>
+  </div>
+{% endif %}

--- a/src/views/components/sign-out-user-banner.njk
+++ b/src/views/components/sign-out-user-banner.njk
@@ -4,9 +4,7 @@
       <span id="signed_in_user_email" class="sign-out-user-banner__email">
         {{ userEmail }}
       </span>
-      <span>
-        <a id="sign_out" href="/signout">Sign out</a>
-      </span>
+      <a id="sign_out" href="/signout" rel="noreferrer">Sign out</a>
     </div>
   </div>
 {% endif %}

--- a/src/views/layout.njk
+++ b/src/views/layout.njk
@@ -46,6 +46,9 @@
       html: 'This is a new service – your <a class="govuk-link" href="https://www.research.net/r/alfp-feedback" target="_blank">feedback</a> will help us to improve it.'
     })
   }}
+
+  {% include "components/sign-out-user-banner.njk" %}
+
   {% block backLink %}{% endblock %}
 {% endblock %}
 


### PR DESCRIPTION
## Description

- Add sign out banner on all internal service pages when user is logged in.
- Move sign out user banner middleware and SessionMiddleware from controller level to server level.

## Coding Standards

Code Style Guide: https://github.com/companieshouse/dissolution-web/wiki/Code-Style-Guide

## Checklist

- [ ] 3 Amigos
- [x] Acceptance Criteria met
- [x] Branch named {feature|hotfix|task}/{S4-*}
- [x] Commit messages are meaningful
- [x] Manually tested
- [x] All unit tests passing
- [x] WAVE accessibility testing tool ran on new or updated pages
- [x] Pulled latest master into feature branch
- [x] Code reviewed
- [ ] New Docker environment variables are consistent with those on the Rebel1 environment
- [ ] If your pull request depends on any other, please link them in the description

## Screenshots of new or updated views
Desktop:
![Screenshot 2020-09-11 at 16 14 54](https://user-images.githubusercontent.com/7227831/92942912-fe08c900-f449-11ea-9a95-5095df7659b9.png)

Mobile:
<img width="499" alt="Screenshot 2020-09-14 at 09 41 13" src="https://user-images.githubusercontent.com/7227831/93063702-8bc4fe00-f66e-11ea-808b-e58c9ecc683b.png">