### PR TITLE
S4-214: Added piwik tracking to hyperlinks

### DIFF
--- a/src/views/check-your-answers.njk
+++ b/src/views/check-your-answers.njk
@@ -55,7 +55,7 @@
             ]
           })
         }}
-        <p class="govuk-!-margin-bottom-9"><a class="govuk-link" href="{{ Paths.SELECT_DIRECTOR_URI }}">Change</a></p>
+        <p class="govuk-!-margin-bottom-9"><a class="govuk-link piwik-event" data-event-id="check-answers-change-email" href="{{ Paths.SELECT_DIRECTOR_URI }}">Change</a></p>
       {% endfor %}
 
       <form method="post">

--- a/src/views/view-final-confirmation.njk
+++ b/src/views/view-final-confirmation.njk
@@ -27,7 +27,7 @@
         You must inform all directors or members that the application has been submitted, including those who signed it.
         They must send a copy of the application to all interested parties within 7 days.</p>
       <p class="govuk-body">Read the <a href="https://www.gov.uk/government/publications/company-strike-off-dissolution-and-restoration/strike-off-dissolution-and-restoration#how-to-apply-for-strike-off-and-who-to-tell"
-                                        target="_blank" class="govuk-link">full list of parties you must tell about the company closing (opens in a new tab)</a>.</p>
+                                        target="_blank" class="govuk-link piwik-event" data-event-id="confirmation-read-guidance">full list of parties you must tell about the company closing (opens in a new tab)</a>.</p>
 
       {{
         govukWarningText({

--- a/src/views/who-to-tell.njk
+++ b/src/views/who-to-tell.njk
@@ -27,7 +27,7 @@
 
       <h1 class="govuk-heading-xl">Who to tell about the company closing</h1>
       <p class="govuk-body">Directors or members must give a copy of this application to all interested parties within 7 days of it being submitted. You can download a PDF copy of the application after you submit it.</p>
-      <p class="govuk-body">Read the <a class="govuk-link" target="_blank" href="{{ documentationUrl }}">full list of interested parties you must tell about the company closing (opens in a new tab)</a>.</p>
+      <p class="govuk-body">Read the <a class="govuk-link piwik-event" data-event-id="who-to-tell-read-guidance" target="_blank" href="{{ documentationUrl }}">full list of interested parties you must tell about the company closing (opens in a new tab)</a>.</p>
 
       {{
         govukWarningText({


### PR DESCRIPTION
## Description

Added a goal trigger for opening the PDF link on the Confirmation page

Added event ids to relevant hyperlinks

- Confirmation page guidance
- Who to tell guidance
- The change link on the check your answers page

## Coding Standards

Code Style Guide: https://github.com/companieshouse/dissolution-web/wiki/Code-Style-Guide

## Checklist

- [x] 3 Amigos
- [ ] Acceptance Criteria met
- [x] Branch named {feature|hotfix|task}/{S4-*}
- [x] Commit messages are meaningful
- [x] Manually tested
- [x] All unit tests passing
- [ ] WAVE accessibility testing tool ran on new or updated pages
- [x] Pulled latest master into feature branch
- [ ] Code reviewed
- [ ] New Docker environment variables are consistent with those on the Rebel1 environment
- [ ] If your pull request depends on any other, please link them in the description

## Screenshots of new or updated views
Added ids:
- check-answers-change-email
- confirmation-read-guidance
- who-to-tell-read-guidance
<img width="1205" alt="Screenshot 2020-09-14 at 13 35 37" src="https://user-images.githubusercontent.com/44438005/93086655-5a105f00-f68f-11ea-9cdc-f7c0a0a15b9d.png">
