### PR TITLE
hotfix/Dependabot ignore private repos

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: "ch-sdk-node"
   - package-ecosystem: "docker"
     directory: "/"
     schedule:


### PR DESCRIPTION
## Description

Dependabot will not work if a private repo is present in the package or package lock. Adding ch-sdk-node to the ignore list in the hope that this will allow dependabot to proceed - https://github.com/companieshouse/dissolution-web/network/updates/60746970

## Coding Standards

Code Style Guide: https://github.com/companieshouse/dissolution-web/wiki/Code-Style-Guide

## Checklist

- [ ] 3 Amigos
- [ ] Acceptance Criteria met
- [x] Branch named {feature|hotfix|task}/{S4-*}
- [x] Commit messages are meaningful
- [ ] Manually tested
- [ ] All unit tests passing
- [ ] WAVE accessibility testing tool ran on new or updated pages
- [x] Pulled latest master into feature branch
- [ ] Code reviewed
- [ ] New Docker environment variables are consistent with those on the Rebel1 environment
- [ ] If your pull request depends on any other, please link them in the description

## Screenshots of new or updated views
