### PR TITLE
S4-214: Added goal trigger for Matomo on Confirmation page PDF link

### DIFF
--- a/src/inversify.config.ts
+++ b/src/inversify.config.ts
@@ -36,7 +36,8 @@ export function initContainer(): Container {
   const piwikConfig: PiwikConfig = {
     url: getEnvOrThrow('PIWIK_URL'),
     siteId: getEnvOrThrow('PIWIK_SITE_ID'),
-    landingPageStartGoalId: getEnvOrThrow('PIWIK_LANDING_PAGE_START_GOAL_ID')
+    landingPageStartGoalId: Number(getEnvOrThrow('PIWIK_LANDING_PAGE_START_GOAL_ID')),
+    confirmationPagePDFGoalId: Number(getEnvOrThrow('PIWIK_CONFIRMATION_PAGE_PDF_GOAL_ID'))
   }
   container.bind<PiwikConfig>(TYPES.PIWIK_CONFIG).toConstantValue(piwikConfig)
 

--- a/src/models/piwikConfig.ts
+++ b/src/models/piwikConfig.ts
@@ -1,5 +1,6 @@
 export default interface PiwikConfig {
   url: string
   siteId: string
-  landingPageStartGoalId: string
+  landingPageStartGoalId: number
+  confirmationPagePDFGoalId: number
 }

--- a/src/views/view-final-confirmation.njk
+++ b/src/views/view-final-confirmation.njk
@@ -20,7 +20,7 @@
 
       <h2 class="govuk-heading-m">What to do next</h2>
 
-      <p class="govuk-body"><a href="{{ Paths.CERTIFICATE_DOWNLOAD_URI }}" target="_blank" class="govuk-link">Download the signed copy of the application (opens in a new tab)</a>.</p>
+      <p class="govuk-body"><a href="{{ Paths.CERTIFICATE_DOWNLOAD_URI }}" target="_blank" onclick="_paq.push(['trackGoal', {{ piwik.confirmationPagePDFGoalId }}]);" class="govuk-link">Download the signed copy of the application (opens in a new tab)</a>.</p>
       <p id="inform" class="govuk-body">
         You must inform all {{ officerType }}s that the application has been submitted, including those who signed it.
         They must send a copy of the application to all interested parties within 7 days.</p>


### PR DESCRIPTION
## Description
Added Javascript to PDF download link to trigger Matomo goal

## Coding Standards

Code Style Guide: https://github.com/companieshouse/dissolution-web/wiki/Code-Style-Guide

## Checklist

- [x] 3 Amigos
- [x] Acceptance Criteria met
- [x] Branch named {feature|hotfix|task}/{S4-*}
- [x] Commit messages are meaningful
- [x] Manually tested
- [x] All unit tests passing
- [ ] WAVE accessibility testing tool ran on new or updated pages
- [x] Pulled latest master into feature branch
- [ ] Code reviewed
- [ ] New Docker environment variables are consistent with those on the Rebel1 environment
- [ ] If your pull request depends on any other, please link them in the description

## Screenshots 
<img width="1180" alt="Screenshot 2020-09-15 at 18 59 42" src="https://user-images.githubusercontent.com/44438005/93247054-9f16bd00-f785-11ea-848b-d100447c1b5c.png">

