### PR TITLE
S4-234: Added other valid officer roles to the officer role enum

### DIFF
--- a/src/models/dto/officerRole.enum.ts
+++ b/src/models/dto/officerRole.enum.ts
@@ -1,6 +1,12 @@
 enum OfficerRole {
   LLP_MEMBER = 'llp-member',
-  DIRECTOR = 'director'
+  DIRECTOR = 'director',
+  CORPORATE_DIRECTOR = 'corporate-director',
+  CORPORATE_NOMINEE_DIRECTOR = 'corporate-nominee-director',
+  JUDICIAL_FACTOR = 'judicial-factor',
+  LLP_DESIGNATED_MEMBER = 'llp-designated-member',
+  CORPORATE_LLP_MEMBER = 'corporate-llp-member',
+  CORPORATE_LLP_DESIGNATED_MEMBER = 'corporate-llp-designated-member'
 }
 
 export default OfficerRole

--- a/src/services/company-officers/companyOfficers.service.ts
+++ b/src/services/company-officers/companyOfficers.service.ts
@@ -15,7 +15,13 @@ export default class CompanyOfficersService {
 
   private readonly VALID_OFFICER_ROLES: string[] = [
     OfficerRole.DIRECTOR,
-    OfficerRole.LLP_MEMBER
+    OfficerRole.CORPORATE_DIRECTOR,
+    OfficerRole.CORPORATE_NOMINEE_DIRECTOR,
+    OfficerRole.JUDICIAL_FACTOR,
+    OfficerRole.LLP_MEMBER,
+    OfficerRole.LLP_DESIGNATED_MEMBER,
+    OfficerRole.CORPORATE_LLP_MEMBER,
+    OfficerRole.CORPORATE_LLP_DESIGNATED_MEMBER
   ]
 
   public constructor(

--- a/test/services/company-officers/companyOfficers.service.test.ts
+++ b/test/services/company-officers/companyOfficers.service.test.ts
@@ -54,21 +54,47 @@ describe('CompanyOfficersService', () => {
 
       const secretary: CompanyOfficer = { ...generateCompanyOfficer(), officerRole: 'secretary' }
       const director: CompanyOfficer = { ...generateCompanyOfficer(), officerRole: OfficerRole.DIRECTOR }
+      const corporateDirector: CompanyOfficer = { ...generateCompanyOfficer(), officerRole: OfficerRole.CORPORATE_DIRECTOR }
+      const corporateNomineeDirector: CompanyOfficer = { ...generateCompanyOfficer(), officerRole: OfficerRole.CORPORATE_NOMINEE_DIRECTOR }
+      const judicialFactor: CompanyOfficer = { ...generateCompanyOfficer(), officerRole: OfficerRole.JUDICIAL_FACTOR }
       const manager: CompanyOfficer = { ...generateCompanyOfficer(), officerRole: 'cicmanager' }
       const llpMember: CompanyOfficer = { ...generateCompanyOfficer(), officerRole: OfficerRole.LLP_MEMBER }
+      const llpDesignatedMember: CompanyOfficer = { ...generateCompanyOfficer(), officerRole: OfficerRole.LLP_DESIGNATED_MEMBER }
+      const corporateLlpMember: CompanyOfficer = { ...generateCompanyOfficer(), officerRole: OfficerRole.CORPORATE_LLP_MEMBER }
+      const corporateLlpDesignatedMember: CompanyOfficer = {
+        ...generateCompanyOfficer(),
+        officerRole: OfficerRole.CORPORATE_LLP_DESIGNATED_MEMBER
+      }
 
       response.resource = {
         ...generateCompanyOfficers(),
-        items: [secretary, director, manager, llpMember]
+        items: [
+          secretary,
+          director,
+          corporateDirector,
+          corporateNomineeDirector,
+          judicialFactor,
+          manager,
+          llpMember,
+          llpDesignatedMember,
+          corporateLlpMember,
+          corporateLlpDesignatedMember
+        ]
       }
 
       when(client.getCompanyOfficers(TOKEN, COMPANY_NUMBER)).thenResolve(response)
 
       await service.getActiveDirectorsForCompany(TOKEN, COMPANY_NUMBER)
 
-      verify(directorMapper.mapToDirectorDetails(anything())).twice()
+      verify(directorMapper.mapToDirectorDetails(anything())).times(8)
       verify(directorMapper.mapToDirectorDetails(director)).once()
+      verify(directorMapper.mapToDirectorDetails(corporateDirector)).once()
+      verify(directorMapper.mapToDirectorDetails(corporateNomineeDirector)).once()
+      verify(directorMapper.mapToDirectorDetails(judicialFactor)).once()
       verify(directorMapper.mapToDirectorDetails(llpMember)).once()
+      verify(directorMapper.mapToDirectorDetails(llpDesignatedMember)).once()
+      verify(directorMapper.mapToDirectorDetails(corporateLlpMember)).once()
+      verify(directorMapper.mapToDirectorDetails(corporateLlpDesignatedMember)).once()
     })
 
     it('should filter directors who have resigned', async () => {


### PR DESCRIPTION
## Description

Added new officer roles to the officer role enum, allowing for more officer roles to be valid during a Dissolution application
New valid roles:

- Corporate Director
- Corporate Nominee Director
- Judical Factor
- LLP Designated Member
- Corporate LLP Member
- Corporate LLP Designated Member

## Coding Standards

Code Style Guide: https://github.com/companieshouse/dissolution-web/wiki/Code-Style-Guide

## Checklist

- [x] 3 Amigos
- [x] Acceptance Criteria met
- [x] Branch named {feature|hotfix|task}/{S4-*}
- [x] Commit messages are meaningful
- [x] Manually tested
- [x] All unit tests passing
- [ ] WAVE accessibility testing tool ran on new or updated pages
- [x] Pulled latest master into feature branch
- [ ] Code reviewed
- [ ] New Docker environment variables are consistent with those on the Rebel1 environment
- [ ] If your pull request depends on any other, please link them in the description

## Screenshots of new or updated views
