### PR TITLE
S4-229 Open source ch-sdk-node and re-enable dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,6 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10
-    ignore:
-      - dependency-name: "ch-sdk-node"
   - package-ecosystem: "docker"
     directory: "/"
     schedule:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1865,8 +1865,8 @@
       }
     },
     "ch-sdk-node": {
-      "version": "git+ssh://git@github.com/companieshouse/ch-sdk-node.git#86a558441e84ade297a997223c9f338b77f0ca0f",
-      "from": "git+ssh://git@github.com/companieshouse/ch-sdk-node.git#86a558441e84ade297a997223c9f338b77f0ca0f",
+      "version": "git+ssh://git@github.com/companieshouse/api-sdk-node.git#0.2.1",
+      "from": "git+ssh://git@github.com/companieshouse/api-sdk-node.git#0.2.1",
       "requires": {
         "camelcase-keys": "~6.2.2",
         "request": "~2.88.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "body-parser": "^1.18.2",
     "ch-logging": "git+ssh://git@github.com/companieshouse/ch-structured-logging-node.git#a3e0dcc57f91f63803e02ceef2cc5e4038de9a19",
     "ch-node-session-handler": "git+ssh://git@github.com/companieshouse/node-session-handler.git#3.0.2",
-    "ch-sdk-node": "git+ssh://git@github.com/companieshouse/ch-sdk-node.git#86a558441e84ade297a997223c9f338b77f0ca0f",
+    "ch-sdk-node": "git+ssh://git@github.com/companieshouse/api-sdk-node.git#0.2.1",
     "cookie-parser": "^1.4.5",
     "crypto": "^1.0.1",
     "dashify": "^2.0.0",

--- a/test/fixtures/companyProfile.fixtures.ts
+++ b/test/fixtures/companyProfile.fixtures.ts
@@ -27,7 +27,8 @@ export function generateCompanyProfile(): CompanyProfile {
     hasInsolvencyHistory: false,
     registeredOfficeAddress: generateRegisteredOfficeAddress(),
     accounts: generateAccounts(),
-    confirmationStatement: generateConfirmationStatement()
+    confirmationStatement: generateConfirmationStatement(),
+    links: {}
   }
 }
 


### PR DESCRIPTION
## Description

Update ch-sdk-node package to use new open source repository and re-enable dependabot

## Jira Ticket

https://companieshouse.atlassian.net/secure/RapidBoard.jspa?rapidView=364&projectKey=S4&modal=detail&selectedIssue=S4-229

## Coding Standards

Code Style Guide: https://github.com/companieshouse/dissolution-web/wiki/Code-Style-Guide

## Checklist

- [ ] 3 Amigos
- [x] Acceptance Criteria met
- [x] Branch named {feature|hotfix|task}/{S4-*}
- [x] Commit messages are meaningful
- [x] Manually tested
- [x] All unit tests passing
- [ ] WAVE accessibility testing tool ran on new or updated pages
- [x] Pulled latest master into feature branch
- [ ] Code reviewed
- [ ] New Docker environment variables are consistent with those on the Rebel1 environment
- [ ] If your pull request depends on any other, please link them in the description

## Screenshots of new or updated views
