### PR TITLE
Excplicitely disable Docker Builkit in Docker build commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Development mode is available for this service in [Docker CHS Development](https
 ## To build the Docker container
 
 1. `export SSH_PRIVATE_KEY_PASSPHRASE='[your SSH key passhprase goes here]'` (optional, set only if SSH key is passphrase protected)
-2. `docker build --build-arg SSH_PRIVATE_KEY="$(cat ~/.ssh/id_rsa)" --build-arg SSH_PRIVATE_KEY_PASSPHRASE -t 169942020521.dkr.ecr.eu-west-1.amazonaws.com/local/dissolution-web:latest .`
+2. `DOCKER_BUILDKIT=0 docker build --build-arg SSH_PRIVATE_KEY="$(cat ~/.ssh/id_rsa)" --build-arg SSH_PRIVATE_KEY_PASSPHRASE -t 169942020521.dkr.ecr.eu-west-1.amazonaws.com/local/dissolution-web:latest .`
 
 ## Controller flow
 

--- a/Tiltfile.dev
+++ b/Tiltfile.dev
@@ -24,7 +24,7 @@ local_resource(
 
 custom_build(
   ref = '169942020521.dkr.ecr.eu-west-1.amazonaws.com/local/dissolution-web',
-  command = 'docker build --build-arg SSH_PRIVATE_KEY="$(cat ~/.ssh/id_rsa)" --build-arg SSH_PRIVATE_KEY_PASSPHRASE --tag $EXPECTED_REF .',
+  command = 'DOCKER_BUILDKIT=0 docker build --build-arg SSH_PRIVATE_KEY="$(cat ~/.ssh/id_rsa)" --build-arg SSH_PRIVATE_KEY_PASSPHRASE --tag $EXPECTED_REF .',
   live_update = [
     sync(
       local_path = './dist',


### PR DESCRIPTION
## Description

Buildkit is not supported by base images but recently it got enabled by Docker by default. This explicitly disables Buildkit in tilt builds and when image is build manually.

## Jira Ticket

Please add link to Jira ticket

## Coding Standards

Code Style Guide: https://github.com/companieshouse/dissolution-web/wiki/Code-Style-Guide

## Checklist

- [ ] 3 Amigos
- [ ] Acceptance Criteria met
- [ ] Branch named {feature|hotfix|task}/{S4-*}
- [ ] Commit messages are meaningful
- [ ] Manually tested
- [ ] All unit tests passing
- [ ] WAVE accessibility testing tool ran on new or updated pages
- [ ] All UI Tests Passing
- [ ] Pulled latest master into feature branch
- [ ] Sonar Analysis
- [ ] New Docker environment variables are consistent with those on the Rebel1 environment
- [ ] If your pull request depends on any other, please link them in the description

## Screenshots of new or updated views
