### PR TITLE
hotfix/S4-254 - Use Application Reference for Payment Resource

### DIFF
--- a/src/services/payment/payment.service.ts
+++ b/src/services/payment/payment.service.ts
@@ -31,8 +31,7 @@ export default class PaymentService {
 
     const applicationReferenceNumber: string = dissolutionSession.applicationReferenceNumber!
 
-    const companyNumber: string = dissolutionSession.companyNumber!
-    const paymentResource: string = `${this.DISSOLUTIONS_API_URL}/dissolution-request/${companyNumber}/payment`
+    const paymentResource: string = `${this.DISSOLUTIONS_API_URL}/dissolution-request/${applicationReferenceNumber}/payment`
 
     const createPaymentRequest: CreatePaymentRequest = this.mapper.mapToCreatePaymentRequest(
       paymentRedirectURI, applicationReferenceNumber, paymentResource, paymentStateUUID


### PR DESCRIPTION
https://github.com/companieshouse/taf-api-karate/pull/238

## Description

Due to refunds reconciliation being async, the dissolution may be marked as inactive before the refund is fully reconciled. This causes a 404 on the dissolution api because the company number does not have an active dissolution.

By using the reference, we no longer have to rely on the active flag as it is always unique.

## Jira Ticket

Please add link to Jira ticket

## Coding Standards

Code Style Guide: https://github.com/companieshouse/dissolution-web/wiki/Code-Style-Guide

## Checklist

- [ ] 3 Amigos
- [ ] Acceptance Criteria met
- [x] Branch named {feature|hotfix|task}/{S4-*}
- [x] Commit messages are meaningful
- [ ] Manually tested
- [x] All unit tests passing
- [ ] WAVE accessibility testing tool ran on new or updated pages
- [ ] All UI Tests Passing
- [x] Pulled latest master into feature branch
- [ ] Sonar Analysis
- [ ] New Docker environment variables are consistent with those on the Rebel1 environment
- [ ] If your pull request depends on any other, please link them in the description

## Screenshots of new or updated views
