### PR TITLE
[WIP] remove presenterauth from URL

### DIFF
--- a/src/services/clients/presenterApi.client.ts
+++ b/src/services/clients/presenterApi.client.ts
@@ -16,7 +16,8 @@ export default class PresenterApiClient {
     @inject(TYPES.AxiosInstance) private axios: AxiosInstance) {}
 
   public async getAccountNumber(params: PresenterAuthRequest): Promise<PresenterAuthResponse> {
-    const response: AxiosResponse<PresenterAuthResponse> = await this.axios.get(this.CHIPS_PRESENTER_AUTH_URL, { params })
+    const response: AxiosResponse<PresenterAuthResponse> = await this.axios
+      .get(`${this.CHIPS_PRESENTER_AUTH_URL}/presenterauth`, { params })
     return response.data
   }
 }

--- a/test/services/clients/presenterApi.client.test.ts
+++ b/test/services/clients/presenterApi.client.test.ts
@@ -17,7 +17,7 @@ describe('PresenterApiClient', () => {
 
   let getStub: sinon.SinonStub
 
-  const CHIPS_PRESENTER_AUTH_URL: string = 'http://presenter-api/presenterauth'
+  const CHIPS_PRESENTER_AUTH_URL: string = 'http://presenter-api'
 
   beforeEach(() => {
     axiosInstance = axios.create()
@@ -38,7 +38,7 @@ describe('PresenterApiClient', () => {
       assert.isTrue(getStub.called)
 
       const [url, config] = getStub.args[0]
-      assert.equal(url, CHIPS_PRESENTER_AUTH_URL)
+      assert.equal(url, `${CHIPS_PRESENTER_AUTH_URL}/presenterauth`)
       assert.equal(config.params, request)
 
       assert.equal(result, response.data)


### PR DESCRIPTION
## Description

For consistency around how we interact with external APIs, there was a need to removed **_/presenterauth_** from URL in config and move it in the app

## Jira Ticket

https://companieshouse.atlassian.net/browse/BI-5813

## Coding Standards

Code Style Guide: https://github.com/companieshouse/dissolution-web/wiki/Code-Style-Guide

## Checklist

- [ ] 3 Amigos
- [ ] Acceptance Criteria met
- [ ] Branch named {feature|hotfix|task}/{S4-*}
- [ ] Commit messages are meaningful
- [ ] Manually tested
- [ ] All unit tests passing
- [ ] WAVE accessibility testing tool ran on new or updated pages
- [ ] All UI Tests Passing
- [ ] Pulled latest master into feature branch
- [ ] Sonar Analysis
- [ ] New Docker environment variables are consistent with those on the Rebel1 environment
- [ ] If your pull request depends on any other, please link them in the description

## Screenshots of new or updated views
