### PR TITLE
Remove text on application signed page

### DIFF
--- a/src/views/wait-for-others-to-sign.njk
+++ b/src/views/wait-for-others-to-sign.njk
@@ -18,7 +18,7 @@
     <div class="govuk-grid-column-two-thirds">
       <p id="email" class="govuk-body">We have emailed the {{ officerType }}s, or those signing on their behalf, asking them to sign the application. It may take some time for them to do this.</p>
 
-      <p class="govuk-body">If they have not yet received the email, we recommend that they check their junk folders. You can also check their details and resend the email below.</p>
+      <p class="govuk-body">If they have not yet received the email, we recommend that they check their junk folders. {% if viewApplicationStatus.signatories.length < 2  %} You can also check their details and resend the email below. {% endif %}</p>
 
       <p class="govuk-body">Alternatively, they can sign the application by signing in to <a href="{{ Paths.ROOT_URI }}">the Apply to strike off and dissolve a company service</a>.</p>
 


### PR DESCRIPTION
## Description

Remove text from the application signed page if filing an e-DS01 for a company of multiple directors. The page should not have '**_You can also check their details and resend the email below_**' if the the dissolution is multi-director.
## Jira Ticket
[BI-7062](https://companieshouse.atlassian.net/browse/BI-7062)

## Coding Standards

Code Style Guide: https://github.com/companieshouse/dissolution-web/wiki/Code-Style-Guide

## Checklist

- [ ] 3 Amigos
- [ ] Acceptance Criteria met
- [x] Branch named {feature|hotfix|task}/{S4-*}
- [x] Commit messages are meaningful
- [x] Manually tested
- [ ] All unit tests passing
- [ ] WAVE accessibility testing tool ran on new or updated pages
- [ ] All UI Tests Passing
- [x] Pulled latest master into feature branch
- [x] Sonar Analysis
- [x] Master branch on Rebel1 and CIDev CI/CD pipeline is green
- [x] Any Docker environment variables added are consistent with those on our upstream environments (Rebel1, CIDev etc)
- [x] If your pull request depends on any other, please link them in the description

## Screenshots of new or updated views
![multi-director](https://user-images.githubusercontent.com/6116440/109512781-5ab17c00-7a9c-11eb-9aaf-54ec3113af3b.png)

![single-director](https://user-images.githubusercontent.com/6116440/109512786-5c7b3f80-7a9c-11eb-9642-0420e9d2c91b.png)
