### PR TITLE
Revert "Remove text on application signed page"

### DIFF
--- a/src/views/wait-for-others-to-sign.njk
+++ b/src/views/wait-for-others-to-sign.njk
@@ -18,7 +18,7 @@
     <div class="govuk-grid-column-two-thirds">
       <p id="email" class="govuk-body">We have emailed the {{ officerType }}s, or those signing on their behalf, asking them to sign the application. It may take some time for them to do this.</p>
 
-      <p class="govuk-body">If they have not yet received the email, we recommend that they check their junk folders. {% if viewApplicationStatus.signatories.length < 2  %} You can also check their details and resend the email below. {% endif %}</p>
+      <p class="govuk-body">If they have not yet received the email, we recommend that they check their junk folders. You can also check their details and resend the email below.</p>
 
       <p class="govuk-body">Alternatively, they can sign the application by signing in to <a href="{{ Paths.ROOT_URI }}">the Apply to strike off and dissolve a company service</a>.</p>
 


### PR DESCRIPTION
Reverts companieshouse/dissolution-web#357

This is because BI-6211 and BI-6212 have been implemented, making this change unnecessary.