### PR TITLE
Add analytics to guidance page

### DIFF
--- a/src/views/landing.njk
+++ b/src/views/landing.njk
@@ -33,7 +33,7 @@
         }}
       </form>
       <h2 class="govuk-heading-m">Before you start</h2>
-      <p class="govuk-body-s">Read the <a href="https://www.gov.uk/government/publications/company-strike-off-dissolution-and-restoration/strike-off-dissolution-and-restoration" target="_blank" class="govuk-link">guidance for striking off and dissolving a company (opens in a new tab)</a>.</p>
+      <p class="govuk-body-s">Read the <a class="piwik-event" data-event-id="eDS01-landing-page-guidance" href="https://www.gov.uk/government/publications/company-strike-off-dissolution-and-restoration/strike-off-dissolution-and-restoration" target="_blank" class="govuk-link">guidance for striking off and dissolving a company (opens in a new tab)</a>.</p>
     </div>
   </div>
   {% if piwik %}


### PR DESCRIPTION
## Description

Add analytics to the read guidance page in close a company landing page.

## Jira Ticket

[BI-7248](https://companieshouse.atlassian.net/browse/BI-7248)

## Coding Standards

Code Style Guide: https://github.com/companieshouse/dissolution-web/wiki/Code-Style-Guide

## Checklist

- [ ] 3 Amigos
- [x] Acceptance Criteria met
- [x] Branch named {feature|hotfix|task}/{S4-*}
- [x] Commit messages are meaningful
- [x] Manually tested
- [x] All unit tests passing
- [ ] WAVE accessibility testing tool ran on new or updated pages
- [x] All UI Tests Passing
- [x] Pulled latest master into feature branch
- [x] Sonar Analysis
- [x] Master branch on Rebel1 and CIDev CI/CD pipeline is green
- [x] Any Docker environment variables added are consistent with those on our upstream environments (Rebel1, CIDev etc)
- [ ] If your pull request depends on any other, please link them in the description

## Screenshots of new or updated views
