### PR TITLE
Add analytics to company help link on company search page

### DIFF
--- a/src/views/search-company.njk
+++ b/src/views/search-company.njk
@@ -49,6 +49,7 @@
             html: '<p>You can find it using the <a href="https://beta.companieshouse.gov.uk/" class="govuk-link" rel="noreferrer noopener" target="_blank">Companies House Service (opens in a new tab)</a>.</p>',
             attributes: {
               'data-event-id': 'help-with-company-number-link' if piwik
+            }
           })
         }}
 

--- a/src/views/search-company.njk
+++ b/src/views/search-company.njk
@@ -46,7 +46,9 @@
         {{  
           govukDetails({
             summaryText: "Help with company number",
-            html: '<p>You can find it using the <a href="https://beta.companieshouse.gov.uk/" class="govuk-link" rel="noreferrer noopener" target="_blank">Companies House Service (opens in a new tab)</a>.</p>'
+            html: '<p>You can find it using the <a href="https://beta.companieshouse.gov.uk/" class="govuk-link" rel="noreferrer noopener" target="_blank">Companies House Service (opens in a new tab)</a>.</p>',
+            attributes: {
+              'data-event-id': 'help-with-company-number-link' if piwik
           })
         }}
 


### PR DESCRIPTION
Add motomo analytics to the company help link on the company search page to track usage 

BI-7238, https://companieshouse.atlassian.net/browse/BI-7238

## Coding Standards

Code Style Guide: https://github.com/companieshouse/dissolution-web/wiki/Code-Style-Guide

## Checklist

- [ ] 3 Amigos
- [x] Acceptance Criteria met
- [x] Branch named {feature|hotfix|task}/{S4-*}
- [x] Commit messages are meaningful
- [x] Manually tested
- [x] All unit tests passing
- [ ] WAVE accessibility testing tool ran on new or updated pages
- [x] All UI Tests Passing
- [x] Pulled latest master into feature branch
- [x] Sonar Analysis
- [x] Master branch on Rebel1 and CIDev CI/CD pipeline is green
- [ ] Any Docker environment variables added are consistent with those on our upstream environments (Rebel1, CIDev etc)
- [ ] If your pull request depends on any other, please link them in the description

## Screenshots of new or updated views
