### PR TITLE
Update banner URL on eDS01 service

### DIFF
--- a/src/paths.ts
+++ b/src/paths.ts
@@ -5,6 +5,7 @@ export const HEALTHCHECK_URI = `${ROOT_URI}/healthcheck`
 // Redirection
 export const REDIRECT_GATE_URI = `${ROOT_URI}/redirect`
 export const PAYMENT_CALLBACK_URI = `${REDIRECT_GATE_URI}/payment-callback`
+export const GOV_UK_URI = `https://gov.uk`
 
 // Error
 export const ERROR_URI = `${ROOT_URI}/error`

--- a/src/views/layout.njk
+++ b/src/views/layout.njk
@@ -36,7 +36,7 @@
 {% block header %}
   {{
     govukHeader({
-      homepageUrl: Paths.ROOT_URI,
+      homepageUrl: Paths.GOV_UK_URI,
       serviceName: serviceName,
       serviceUrl: Paths.ROOT_URI,
       containerClasses: 'govuk-width-container'


### PR DESCRIPTION
Update banner URL on eDS01 service so that the user is taken to https://gov.uk 

https://companieshouse.atlassian.net/browse/BI-7494

## Coding Standards

Code Style Guide: https://github.com/companieshouse/dissolution-web/wiki/Code-Style-Guide

## Checklist

- [x] 3 Amigos
- [x] Acceptance Criteria met
- [x] Branch named {feature|hotfix|task}/{S4-*}
- [x] Commit messages are meaningful
- [x] Manually tested
- [x] All unit tests passing
- [x] WAVE accessibility testing tool ran on new or updated pages
- [x] All UI Tests Passing
- [x] Pulled latest master into feature branch
- [x] Sonar Analysis
- [x] Master branch on Rebel1 and CIDev CI/CD pipeline is green
- [ ] Any Docker environment variables added are consistent with those on our upstream environments (Rebel1, CIDev etc)
- [ ] If your pull request depends on any other, please link them in the description

## Screenshots of new or updated views
