### PR TITLE
Prevent double-click on payment select button

### DIFF
--- a/src/views/how-do-you-want-to-pay.njk
+++ b/src/views/how-do-you-want-to-pay.njk
@@ -60,7 +60,8 @@
           govukButton({
             text: 'Continue',
             attributes: {
-              id: 'submit'
+              id: 'submit',
+              preventDoubleClick: true
             }
           })
         }}


### PR DESCRIPTION
Prevent double-clicking payment select, which was causing issues creating multiple payment sessions
https://design-system.service.gov.uk/components/button/

BI-13283
