### PR TITLE
Permit Access to S3 Bucket

### DIFF
--- a/terraform/groups/ecs-service/iam.tf
+++ b/terraform/groups/ecs-service/iam.tf
@@ -1,0 +1,54 @@
+resource "aws_iam_role" "task_role" {
+  name               = "${local.name_prefix}-task-role"
+  path               = "/"
+  assume_role_policy = data.aws_iam_policy_document.task_assume.json
+}
+
+data "aws_iam_policy_document" "task_assume" {
+  statement {
+    sid     = "AllowTaskAssumeRole"
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_policy" "task_policy" {
+  name        = "${local.name_prefix}-task-policy"
+  policy      = data.aws_iam_policy_document.task_policy.json
+}
+
+data "aws_iam_policy_document" "task_policy" {
+  statement {
+    sid       = "AllowS3ListBuckets"
+    effect    = "Allow"
+    actions   = [
+      "s3:ListBucket"
+    ]
+    resources = [
+      "arn:aws:s3:::${local.dissolutions_bucket_name}"
+    ]
+  }
+
+  statement {
+    sid       = "AllowS3ReadObjects"
+    effect    = "Allow"
+    actions   = [
+      "s3:GetBucketPolicy",
+      "s3:GetLifecycleConfiguration",
+      "s3:GetObject"
+    ]
+    resources = [
+      "arn:aws:s3:::${local.dissolutions_bucket_name}/*"
+    ]
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "task_role_attachment" {
+  role       = aws_iam_role.task_role.name
+  policy_arn = aws_iam_policy.task_policy.arn
+}

--- a/terraform/groups/ecs-service/locals.tf
+++ b/terraform/groups/ecs-service/locals.tf
@@ -17,6 +17,7 @@ locals {
   use_set_environment_files   = var.use_set_environment_files
   application_subnet_ids      = data.aws_subnets.application.ids
   application_subnet_pattern  = local.stack_secrets["application_subnet_pattern"]
+  dissolutions_bucket_name    = local.service_secrets["dissolutions_bucket_name"]
 
   stack_secrets               = jsondecode(data.vault_generic_secret.stack_secrets.data_json)
   service_secrets             = jsondecode(data.vault_generic_secret.service_secrets.data_json)

--- a/terraform/groups/ecs-service/main.tf
+++ b/terraform/groups/ecs-service/main.tf
@@ -39,6 +39,7 @@ module "ecs-service" {
   vpc_id                  = data.aws_vpc.vpc.id
   ecs_cluster_id          = data.aws_ecs_cluster.ecs_cluster.id
   task_execution_role_arn = data.aws_iam_role.ecs_cluster_iam_role.arn
+  task_role_arn           = aws_iam_role.task_role.arn
 
   # Load balancer configuration
   lb_listener_arn                 = data.aws_lb_listener.service_lb_listener.arn


### PR DESCRIPTION
Added IAM policies and role to permit access to Dissolutions S3 bucket
Passed to `ecs-service` module via `task_role_arn` argument
Added supporting Vault data

Resolves: CC-861