### PR TITLE
CDN fix for Content-Security-Policy

### DIFF
--- a/src/inversify.config.ts
+++ b/src/inversify.config.ts
@@ -28,6 +28,7 @@ export function initContainer (): Container {
 
     // Env
     container.bind<string>(TYPES.CDN_HOST).toConstantValue(getEnvOrThrow("CDN_HOST"))
+    container.bind<boolean>(TYPES.CDN_HOST_LONG_PREFIX).toConstantValue(Boolean(getEnvOrThrow("CDN_HOST_LONG_PREFIX")))
     container.bind<string>(TYPES.CHIPS_PRESENTER_AUTH_URL).toConstantValue(getEnvOrThrow("CHIPS_PRESENTER_AUTH_URL"))
     container.bind<string>(TYPES.CHS_API_KEY).toConstantValue((getEnvOrThrow("CHS_API_KEY")))
     container.bind<string>(TYPES.CHS_COMPANY_PROFILE_API_LOCAL_URL).toConstantValue(getEnvOrThrow("CHS_COMPANY_PROFILE_API_LOCAL_URL"))

--- a/src/inversify.config.ts
+++ b/src/inversify.config.ts
@@ -25,22 +25,22 @@ import { getEnv, getEnvOrDefault, getEnvOrThrow } from "app/utils/env.util"
 import UriFactory from "app/utils/uri.factory"
 
 function initCSP (): string {
-   let cdn = <string> getEnv("CDN_HOST")
-   let csp_cdn = cdn
-   // Check if the cdn starts with a valid protocol, if not add one to have a valid URL
-   if (!/^https?:\/\//i.test(cdn)) {
-         cdn = 'https://' + cdn
-   }
+    let cdn = <string> getEnv("CDN_HOST")
+    let csp_cdn = cdn
+    // Check if the cdn starts with a valid protocol, if not add one to have a valid URL
+    if (!/^https?:\/\//i.test(cdn)) {
+        cdn = "https://" + cdn
+    }
 
-   const parsedUrl = new URL(cdn)
-   if (!!parsedUrl.pathname &&
+    const parsedUrl = new URL(cdn)
+    if (!!parsedUrl.pathname &&
          parsedUrl.pathname !== "/" &&
          !cdn.endsWith("/")) {
 
       csp_cdn += "/"
-   }
-   return csp_cdn
-  }
+    }
+    return csp_cdn
+}
 
 export function initContainer (): Container {
     const container: Container = new Container()

--- a/src/inversify.config.ts
+++ b/src/inversify.config.ts
@@ -37,7 +37,7 @@ function initCSP (): string {
          parsedUrl.pathname !== "/" &&
          !cdn.endsWith("/")) {
 
-      csp_cdn += "/"
+        csp_cdn += "/"
     }
     return csp_cdn
 }

--- a/src/inversify.config.ts
+++ b/src/inversify.config.ts
@@ -25,21 +25,21 @@ import { getEnv, getEnvOrDefault, getEnvOrThrow } from "app/utils/env.util"
 import UriFactory from "app/utils/uri.factory"
 
 function initCSP (): string {
-      let cdn = <string> getEnv("CDN_HOST")
-      let csp_cdn = cdn
-      // Check if the cdn starts with a valid protocol, if not add one to have a valid URL
-      if (!/^https?:\/\//i.test(cdn)) {
-          cdn = 'https://' + cdn
-      }
+   let cdn = <string> getEnv("CDN_HOST")
+   let csp_cdn = cdn
+   // Check if the cdn starts with a valid protocol, if not add one to have a valid URL
+   if (!/^https?:\/\//i.test(cdn)) {
+         cdn = 'https://' + cdn
+   }
 
-      const parsedUrl = new URL(cdn)
-      if ( !!parsedUrl.pathname &&
-             parsedUrl.pathname !== '/' &&
-           ! cdn.endsWith('/')) {
+   const parsedUrl = new URL(cdn)
+   if (!!parsedUrl.pathname &&
+         parsedUrl.pathname !== "/" &&
+         !cdn.endsWith("/")) {
 
-         csp_cdn += '/'
-      }
-      return csp_cdn
+      csp_cdn += "/"
+   }
+   return csp_cdn
   }
 
 export function initContainer (): Container {

--- a/src/middleware/serverMiddlewareLoader.middleware.ts
+++ b/src/middleware/serverMiddlewareLoader.middleware.ts
@@ -23,8 +23,7 @@ import TYPES from "app/types"
 export default class ServerMiddlewareLoader {
 
     public constructor (
-    @inject(TYPES.CDN_HOST) private CDN_HOST: string,
-    @inject(TYPES.CDN_HOST_LONG_PREFIX) private CDN_HOST_LONG_PREFIX: boolean,
+    @inject(TYPES.CSP_CDN_HOST) private CSP_CDN_HOST: string,
     @inject(TYPES.PIWIK_CONFIG) private PIWIK_CONFIG: PiwikConfig,
     @inject(NunjucksLoader) private nunjucks: NunjucksLoader,
     @inject(ApplicationLogger) private logger: ApplicationLogger,
@@ -75,22 +74,17 @@ export default class ServerMiddlewareLoader {
 
     private prepareCSPConfig (nonce: string): ContentSecurityPolicyOptions {
         const piwikConfig = ServerMiddlewareLoader.extractPiwikHost(this.PIWIK_CONFIG)
-        let cdnHostPrefix: string = this.CDN_HOST
-        if ( this.CDN_HOST_LONG_PREFIX &&
-             ! cdnHostPrefix.endsWith('/')) {
-               cdnHostPrefix += '/'
-        }
         return {
             directives: {
                 defaultSrc: [`'self'`, piwikConfig],
-                scriptSrc: [`'self'`, "code.jquery.com", cdnHostPrefix, `'nonce-${nonce}'`,
+                scriptSrc: [`'self'`, "code.jquery.com", this.CSP_CDN_HOST, `'nonce-${nonce}'`,
                     piwikConfig,
                     `'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU='`],
                 connectSrc: [`'self'`, piwikConfig],
                 objectSrc: [`'none'`],
-                fontSrc: [`'self'`, cdnHostPrefix],
-                styleSrc: [`'self'`, cdnHostPrefix],
-                imgSrc: [`'self'`, cdnHostPrefix, piwikConfig]
+                fontSrc: [`'self'`, this.CSP_CDN_HOST],
+                styleSrc: [`'self'`, this.CSP_CDN_HOST],
+                imgSrc: [`'self'`, this.CSP_CDN_HOST, piwikConfig]
             }
         }
     }

--- a/src/middleware/serverMiddlewareLoader.middleware.ts
+++ b/src/middleware/serverMiddlewareLoader.middleware.ts
@@ -24,6 +24,7 @@ export default class ServerMiddlewareLoader {
 
     public constructor (
     @inject(TYPES.CDN_HOST) private CDN_HOST: string,
+    @inject(TYPES.CDN_HOST_LONG_PREFIX) private CDN_HOST_LONG_PREFIX: boolean,
     @inject(TYPES.PIWIK_CONFIG) private PIWIK_CONFIG: PiwikConfig,
     @inject(NunjucksLoader) private nunjucks: NunjucksLoader,
     @inject(ApplicationLogger) private logger: ApplicationLogger,
@@ -74,17 +75,22 @@ export default class ServerMiddlewareLoader {
 
     private prepareCSPConfig (nonce: string): ContentSecurityPolicyOptions {
         const piwikConfig = ServerMiddlewareLoader.extractPiwikHost(this.PIWIK_CONFIG)
+        let cdnHostPrefix: string = this.CDN_HOST
+        if ( this.CDN_HOST_LONG_PREFIX &&
+             ! cdnHostPrefix.endsWith('/')) {
+               cdnHostPrefix += '/'
+        }
         return {
             directives: {
                 defaultSrc: [`'self'`, piwikConfig],
-                scriptSrc: [`'self'`, "code.jquery.com", this.CDN_HOST, `'nonce-${nonce}'`,
+                scriptSrc: [`'self'`, "code.jquery.com", cdnHostPrefix, `'nonce-${nonce}'`,
                     piwikConfig,
                     `'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU='`],
                 connectSrc: [`'self'`, piwikConfig],
                 objectSrc: [`'none'`],
-                fontSrc: [`'self'`, this.CDN_HOST],
-                styleSrc: [`'self'`, this.CDN_HOST],
-                imgSrc: [`'self'`, this.CDN_HOST, piwikConfig]
+                fontSrc: [`'self'`, cdnHostPrefix],
+                styleSrc: [`'self'`, cdnHostPrefix],
+                imgSrc: [`'self'`, cdnHostPrefix, piwikConfig]
             }
         }
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,7 +3,7 @@ const TYPES = {
     AxiosInstance: "AxiosInstance",
     CompanyAuthMiddleware: "CompanyAuthMiddleware",
     CDN_HOST: "CDN_HOST",
-    CDN_HOST_LONG_PREFIX: "CDN_HOST_LONG_PREFIX",
+    CSP_CDN_HOST: "CSP_CDN_HOST",
     CHIPS_PRESENTER_AUTH_URL: "CHIPS_PRESENTER_AUTH_URL",
     CHS_API_KEY: "CHS_API_KEY",
     CHS_URL: "CHS_URL",

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,7 @@ const TYPES = {
     AxiosInstance: "AxiosInstance",
     CompanyAuthMiddleware: "CompanyAuthMiddleware",
     CDN_HOST: "CDN_HOST",
+    CDN_HOST_LONG_PREFIX: "CDN_HOST_LONG_PREFIX",
     CHIPS_PRESENTER_AUTH_URL: "CHIPS_PRESENTER_AUTH_URL",
     CHS_API_KEY: "CHS_API_KEY",
     CHS_URL: "CHS_URL",


### PR DESCRIPTION
## Description

Add a slash `/` to `CDN_HOST` when handling `Content-Security-Policy`.
This is required when `CDN_HOST` rather than just the host
ex:
```
d29ujl8n7pu7k5.cloudfront.net
```
contains a longer prefix
```
d29ujl8n7pu7k5.cloudfront.net/cidev
                             ^^^^^^
```

## Jira Ticket

Please add link to Jira ticket

## Coding Standards

Code Style Guide: https://github.com/companieshouse/dissolution-web/wiki/Code-Style-Guide

## Checklist

- [ ] 3 Amigos
- [ ] Acceptance Criteria met
- [ ] Branch named {feature|hotfix|task}/{S4-*}
- [ ] Commit messages are meaningful
- [X] Manually tested
- [X] All unit tests passing
- [ ] WAVE accessibility testing tool ran on new or updated pages
- [ ] All UI Tests Passing
- [ ] Pulled latest master into feature branch
- [ ] Sonar Analysis
- [ ] Master branch on Rebel1 and CIDev CI/CD pipeline is green
- [ ] Any Docker environment variables added are consistent with those on our upstream environments (Rebel1, CIDev etc)
- [ ] If your pull request depends on any other, please link them in the description

## Screenshots of new or updated views
