### PR TITLE
feat/sec-65: add csrf tokens to web journey

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,10 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "@companieshouse/api-sdk-node": "^2.0.137",
-        "@companieshouse/node-session-handler": "^5.0.1",
+        "@companieshouse/api-sdk-node": "^2.0.222",
+        "@companieshouse/node-session-handler": "^5.2.0",
         "@companieshouse/structured-logging-node": "^2.0.1",
-        "@companieshouse/web-security-node": "2.0.5",
+        "@companieshouse/web-security-node": "^4.4.4",
         "@hapi/joi": "^17.1.1",
         "aws-sdk": "^2.792.0",
         "axios": "^1.6.5",
@@ -410,20 +410,21 @@
       }
     },
     "node_modules/@companieshouse/api-sdk-node": {
-      "version": "2.0.139",
-      "resolved": "https://registry.npmjs.org/@companieshouse/api-sdk-node/-/api-sdk-node-2.0.139.tgz",
-      "integrity": "sha512-28msQfGdPtduJQ0UnikVUxg3IFLwcoV0+7vMw6cq/GvLO/ywQdPg7pHbAQ3Y6VrUdcqNjCHaqHDV+EAMmjlhgw==",
+      "version": "2.0.222",
+      "resolved": "https://registry.npmjs.org/@companieshouse/api-sdk-node/-/api-sdk-node-2.0.222.tgz",
+      "integrity": "sha512-L6gbD9ntIvPH6XynziGh7BH/Tkjt2yo6Bh3mRX2l4Lb8/sJPdj8Ib/MxI+lb2W10q5nEaTzzT81h0FVDDh+0jQ==",
       "dependencies": {
-        "axios": "^1.6.1",
+        "axios": "^1.7.4",
         "camelcase-keys": "~6.2.2",
+        "http-status-codes": "^2.3.0",
         "snakecase-keys": "~3.2.0",
         "url-search-params-polyfill": "~8.1.1"
       }
     },
     "node_modules/@companieshouse/node-session-handler": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@companieshouse/node-session-handler/-/node-session-handler-5.0.1.tgz",
-      "integrity": "sha512-oCcKHcBA7nyOjnBtTQEdYdf7ycgMXUopsAQEAi4icCHVOrjPgLquh8sfDn0KlQuGaJH91G6SkkWpl1eqnsF1Jw==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@companieshouse/node-session-handler/-/node-session-handler-5.2.0.tgz",
+      "integrity": "sha512-9ihSGNwx/chZlaHxy5eCKdI6V7I7kNIRhpy9O6ZjE+5jkhfn0qArUdtGnzl7AhknS4OWGGOTiinuV0ZTbO0tjQ==",
       "dependencies": {
         "@companieshouse/structured-logging-node": "^1.0.0",
         "crypto": "^1.0.1",
@@ -454,12 +455,26 @@
       }
     },
     "node_modules/@companieshouse/web-security-node": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@companieshouse/web-security-node/-/web-security-node-2.0.5.tgz",
-      "integrity": "sha512-uiCrZiavQ0Scg3T02vHRlMIZwbqb5VdLGR1R6oeU4tEMLrvMtiVV/KCrLyjdJwVphbsqybtxE5XhE/4rBdFgBQ==",
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@companieshouse/web-security-node/-/web-security-node-4.4.4.tgz",
+      "integrity": "sha512-azwlVFUnzK3B9oyGDwxRfDGzrcHS2IxCGAqJUO3XyfsJu1J55Z6yEgwYl5a2nMb4dymvrBTjvTWza8q2t62C9g==",
       "dependencies": {
-        "@companieshouse/node-session-handler": "~5.0.1",
-        "@companieshouse/structured-logging-node": "~2.0.1"
+        "@companieshouse/node-session-handler": "~5.2.0",
+        "@companieshouse/structured-logging-node": "~2.0.1",
+        "express-async-handler": "^1.2.0",
+        "uuid": "^9.0.1"
+      }
+    },
+    "node_modules/@companieshouse/web-security-node/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -1899,11 +1914,11 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.6.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.5.tgz",
-      "integrity": "sha512-Ii012v05KEVuUoFWmMW/UQv9aRIc3ZwkWDcM+h5Il8izZCtRVpDUfwpoFf7eOtajT3QiGR4yDUx7lPqHJULgbg==",
+      "version": "1.7.9",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
+      "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
       "dependencies": {
-        "follow-redirects": "^1.15.4",
+        "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       }
@@ -4773,9 +4788,9 @@
       "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.5",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
-      "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==",
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
       "funding": [
         {
           "type": "individual",

--- a/package.json
+++ b/package.json
@@ -21,10 +21,10 @@
     "analyse-code": "sonar-scanner"
   },
   "dependencies": {
-    "@companieshouse/api-sdk-node": "^2.0.137",
-    "@companieshouse/node-session-handler": "^5.0.1",
+    "@companieshouse/api-sdk-node": "^2.0.222",
+    "@companieshouse/node-session-handler": "^5.2.0",
     "@companieshouse/structured-logging-node": "^2.0.1",
-    "@companieshouse/web-security-node": "2.0.5",
+    "@companieshouse/web-security-node": "^4.4.4",
     "@hapi/joi": "^17.1.1",
     "aws-sdk": "^2.792.0",
     "axios": "^1.6.5",

--- a/src/constants/app.const.ts
+++ b/src/constants/app.const.ts
@@ -8,3 +8,4 @@ export const NO_ACTIVE_DIRECTORS_ERROR_MSG = "The company has no active director
 export const NO_ACTIVE_MEMBERS_ERROR_MSG = "The company has no active members."
 export const BANNER_FEEDBACK_LINK = "https://www.smartsurvey.co.uk/s/closing-a-company-feedback"
 export const CONFIRMATION_FEEDBACK_LINK = "https://www.smartsurvey.co.uk/s/closing-a-company-confirmation"
+export const CSRF_ENABLED = true

--- a/src/controllers/landing.controller.ts
+++ b/src/controllers/landing.controller.ts
@@ -1,4 +1,4 @@
-import { controller, httpGet, httpPost } from "inversify-express-utils"
+import { controller, httpGet } from "inversify-express-utils"
 
 import BaseController from "app/controllers/base.controller"
 import { ROOT_URI, WHO_TO_TELL_URI } from "app/paths"
@@ -11,10 +11,5 @@ export class LandingController extends BaseController {
         return super.render("landing", {
             redirectUrl: `${WHO_TO_TELL_URI}`
         })
-    }
-
-    @httpPost('')
-    public post (): void {
-        this.httpContext.response.redirect(WHO_TO_TELL_URI)
     }
 }

--- a/src/controllers/landing.controller.ts
+++ b/src/controllers/landing.controller.ts
@@ -8,7 +8,9 @@ export class LandingController extends BaseController {
 
     @httpGet('')
     public async get (): Promise<string> {
-        return super.render("landing")
+        return super.render("landing", {
+            redirectUrl: `${WHO_TO_TELL_URI}`
+        })
     }
 
     @httpPost('')

--- a/src/inversify.config.ts
+++ b/src/inversify.config.ts
@@ -24,6 +24,7 @@ import { getEnv, getEnvOrDefault, getEnvOrThrow } from "app/utils/env.util"
 import UriFactory from "app/utils/uri.factory"
 
 export function initContainer (): Container {
+
     const container: Container = new Container()
 
     // Env
@@ -35,6 +36,7 @@ export function initContainer (): Container {
     container.bind<string>(TYPES.DISSOLUTIONS_API_URL).toConstantValue(getEnvOrThrow("DISSOLUTIONS_API_URL"))
     container.bind<Optional<string>>(TYPES.NODE_ENV).toConstantValue(getEnv("NODE_ENV"))
     container.bind<string>(TYPES.PAYMENTS_API_URL).toConstantValue(getEnvOrThrow("PAYMENTS_API_URL"))
+
     const piwikConfig: PiwikConfig = {
         url: getEnvOrThrow("PIWIK_URL"),
         siteId: getEnvOrThrow("PIWIK_SITE_ID"),
@@ -47,6 +49,7 @@ export function initContainer (): Container {
         multiDirectorConfirmationGoalId: Number(getEnvOrThrow("PIWIK_MULTI_DIRECTOR_CONFIRMATION_GOAL_ID")),
         singleDirectorConfirmationGoalId: Number(getEnvOrThrow("PIWIK_SINGLE_DIRECTOR_CONFIRMATION_GOAL_ID"))
     }
+
     container.bind<PiwikConfig>(TYPES.PIWIK_CONFIG).toConstantValue(piwikConfig)
     container.bind<number>(TYPES.PORT).toConstantValue(Number(getEnvOrDefault("PORT", "3000")))
 
@@ -86,6 +89,7 @@ export function initContainer (): Container {
         accountClientId: getEnvOrThrow("OAUTH2_CLIENT_ID"),
         chsUrl: getEnvOrThrow("CHS_URL")
     }
+
     container.bind(TYPES.CompanyAuthMiddleware).toConstantValue(
         CompanyAuthMiddleware(authConfig, new JwtEncryptionService(authConfig), sessionService, logger)
     )

--- a/src/middleware/auth.middleware.ts
+++ b/src/middleware/auth.middleware.ts
@@ -1,14 +1,17 @@
 import { AuthOptions } from "@companieshouse/web-security-node"
 import { NextFunction, Request, RequestHandler, Response } from "express"
-
-import { ACCESSIBILITY_STATEMENT_URI, HEALTHCHECK_URI, ROOT_URI, SEARCH_COMPANY_URI, WHO_TO_TELL_URI } from "app/paths"
 import UriFactory from "app/utils/uri.factory"
+
+import {
+    ROOT_URI,
+    HEALTHCHECK_URI,
+    WHO_TO_TELL_URI,
+    ACCESSIBILITY_STATEMENT_URI
+} from "app/paths"
 
 const USER_AUTH_WHITELISTED_URLS: string[] = [
     ROOT_URI,
     `${ROOT_URI}/`,
-    WHO_TO_TELL_URI,
-    `${WHO_TO_TELL_URI}/`,
     HEALTHCHECK_URI,
     `${HEALTHCHECK_URI}/`,
     ACCESSIBILITY_STATEMENT_URI,
@@ -22,12 +25,10 @@ export default function AuthMiddleware (
         if (isWhitelistedUrl(req.url)) {
             return next()
         }
-
         const authOptions: AuthOptions = {
-            returnUrl: uriFactory.createAbsoluteUri(req, SEARCH_COMPANY_URI),
+            returnUrl: uriFactory.createAbsoluteUri(req, WHO_TO_TELL_URI),
             chsWebUrl: accountWebUrl
         }
-
         return commonAuthMiddleware(authOptions)(req, res, next)
     }
 }

--- a/src/middleware/companyAuth.middleware.ts
+++ b/src/middleware/companyAuth.middleware.ts
@@ -1,14 +1,21 @@
+import { NextFunction, Request, RequestHandler, Response } from "express"
 import { SignInInfoKeys } from "@companieshouse/node-session-handler/lib/session/keys/SignInInfoKeys"
 import { ISignInInfo } from "@companieshouse/node-session-handler/lib/session/model/SessionInterfaces"
 import ApplicationLogger from "@companieshouse/structured-logging-node/lib/ApplicationLogger"
-import { NextFunction, Request, RequestHandler, Response } from "express"
 
 import AuthConfig from "app/models/authConfig"
 import Optional from "app/models/optional"
 import DissolutionSession from "app/models/session/dissolutionSession.model"
-import { ACCESSIBILITY_STATEMENT_URI, HEALTHCHECK_URI, ROOT_URI, SEARCH_COMPANY_URI, VIEW_COMPANY_INFORMATION_URI, WHO_TO_TELL_URI } from "app/paths"
 import JwtEncryptionService from "app/services/encryption/jwtEncryption.service"
 import SessionService from "app/services/session/session.service"
+
+import {
+    ACCESSIBILITY_STATEMENT_URI,
+    HEALTHCHECK_URI, ROOT_URI,
+    SEARCH_COMPANY_URI,
+    VIEW_COMPANY_INFORMATION_URI,
+    WHO_TO_TELL_URI
+} from "app/paths"
 
 const OAUTH_COMPANY_SCOPE_PREFIX = "https://api.companieshouse.gov.uk/company/"
 const OAUTH_USER_SCOPE = "https://account.companieshouse.gov.uk/user.write-full"

--- a/src/middleware/customServerMiddlewareLoader.middleware.ts
+++ b/src/middleware/customServerMiddlewareLoader.middleware.ts
@@ -19,7 +19,6 @@ export default class CustomServerMiddlewareLoader {
     public loadCustomServerMiddleware (app: Application): void {
         app.use(this.sessionMiddleware)
         app.use(this.saveUserEmailToLocals)
-
         app.use(this.authMiddleware)
         app.use(this.companyAuthMiddleware)
     }

--- a/src/middleware/nunjucksLoader.middleware.ts
+++ b/src/middleware/nunjucksLoader.middleware.ts
@@ -1,16 +1,20 @@
 import "reflect-metadata"
-
 import * as express from "express"
 import { inject } from "inversify"
 import { provide } from "inversify-binding-decorators"
 import nunjucks from "nunjucks"
 import * as path from "path"
-
-import { BANNER_FEEDBACK_LINK, CONFIRMATION_FEEDBACK_LINK, PAGE_TITLE_SUFFIX, SERVICE_NAME } from "app/constants/app.const"
 import PiwikConfig from "app/models/piwikConfig"
 import { ROOT_URI } from "app/paths"
 import TYPES from "app/types"
 import { addFilters, addGlobals } from "app/utils/nunjucks.util"
+
+import {
+    BANNER_FEEDBACK_LINK,
+    CONFIRMATION_FEEDBACK_LINK,
+    PAGE_TITLE_SUFFIX,
+    SERVICE_NAME
+} from "app/constants/app.const"
 
 @provide(NunjucksLoader)
 export default class NunjucksLoader {
@@ -33,7 +37,8 @@ export default class NunjucksLoader {
             [
                 "dist/views",
                 "node_modules/govuk-frontend",
-                "node_modules/govuk-frontend/components"
+                "node_modules/govuk-frontend/components",
+                "node_modules/@companieshouse"
             ],
             {
                 autoescape: true,
@@ -57,17 +62,11 @@ export default class NunjucksLoader {
         }
 
         app.locals.piwik = this.PIWIK_CONFIG
-
         app.locals.serviceName = SERVICE_NAME
-
         app.locals.pageTitleSuffix = PAGE_TITLE_SUFFIX
-
         app.locals.nonce = nonce
-
         app.locals.payByAccountFeatureEnabled = this.PAY_BY_ACCOUNT_FEATURE_ENABLED
-
         app.locals.bannerFeedbackLink = BANNER_FEEDBACK_LINK
-
         app.locals.confirmationFeedbackLink = CONFIRMATION_FEEDBACK_LINK
     }
 }

--- a/src/middleware/saveUserEmailToLocals.middleware.ts
+++ b/src/middleware/saveUserEmailToLocals.middleware.ts
@@ -7,7 +7,6 @@ export default function SaveUserEmailToLocals (sessionService: SessionService): 
         if (req.session) {
             res.locals.userEmail = sessionService.getUserEmail(req)
         }
-
         return next()
     }
 }

--- a/src/middleware/serverMiddlewareLoader.middleware.ts
+++ b/src/middleware/serverMiddlewareLoader.middleware.ts
@@ -1,23 +1,27 @@
 import "reflect-metadata"
 
-import { createLoggerMiddleware } from "@companieshouse/structured-logging-node"
-import ApplicationLogger from "@companieshouse/structured-logging-node/lib/ApplicationLogger"
+import IORedis from "ioredis"
 import bodyParser from "body-parser"
 import cookieParser from "cookie-parser"
 import { Application, NextFunction, Request, Response } from "express"
 import helmet from "helmet"
-import { ContentSecurityPolicyOptions } from "helmet/dist/middlewares/content-security-policy"
 import { StatusCodes } from "http-status-codes"
 import { inject } from "inversify"
 import { provide } from "inversify-binding-decorators"
 import nocache from "nocache"
 import { v4 as uuidv4 } from "uuid"
+import { ContentSecurityPolicyOptions } from "helmet/dist/middlewares/content-security-policy"
+
+import { createLoggerMiddleware } from "@companieshouse/structured-logging-node"
+import ApplicationLogger from "@companieshouse/structured-logging-node/lib/ApplicationLogger"
+import { CsrfProtectionMiddleware } from "@companieshouse/web-security-node"
+import { SessionStore } from "@companieshouse/node-session-handler"
 import CustomServerMiddlewareLoader from "./customServerMiddlewareLoader.middleware"
 import NunjucksLoader from "./nunjucksLoader.middleware"
-
-import { APP_NAME } from "app/constants/app.const"
+import { APP_NAME, CSRF_ENABLED } from "app/constants/app.const"
 import PiwikConfig from "app/models/piwikConfig"
 import TYPES from "app/types"
+import { getEnvOrThrow } from "app/utils/env.util"
 
 @provide(ServerMiddlewareLoader)
 export default class ServerMiddlewareLoader {
@@ -41,14 +45,20 @@ export default class ServerMiddlewareLoader {
         this.setHeaders(app, nonce)
 
         this.customServerMiddlewareLoader.loadCustomServerMiddleware(app)
+        const sessionStore = new SessionStore(new IORedis(`${getEnvOrThrow("CACHE_SERVER")}`))
 
+        const csrfProtectionMiddleware = CsrfProtectionMiddleware({
+            sessionStore,
+            enabled: CSRF_ENABLED,
+            sessionCookieName: getEnvOrThrow("COOKIE_NAME")
+        })
+        app.use(csrfProtectionMiddleware)
         this.nunjucks.configureNunjucks(app, directory, nonce)
     }
 
     public configureErrorHandling (app: Application): void {
         app.use((err: any, _: Request, res: Response, _2: NextFunction) => {
             this.logger.error(`${err.constructor.name} - ${err.message}`)
-
             return res.status(err.status || StatusCodes.INTERNAL_SERVER_ERROR).render("error")
         })
     }
@@ -59,7 +69,6 @@ export default class ServerMiddlewareLoader {
 
     private setHeaders (app: Application, nonce: string): void {
         const ONE_YEAR_SECONDS = 31536000
-
         app.use(nocache())
         app.use(
             helmet({

--- a/src/middleware/serverMiddlewareLoader.middleware.ts
+++ b/src/middleware/serverMiddlewareLoader.middleware.ts
@@ -36,14 +36,15 @@ export default class ServerMiddlewareLoader {
     }
 
     public loadServerMiddleware (app: Application, directory: string): void {
+
         const nonce: string = uuidv4()
 
         app.use(bodyParser.json())
         app.use(bodyParser.urlencoded({ extended: true }))
         app.use(cookieParser())
         app.use(createLoggerMiddleware(APP_NAME))
-        this.setHeaders(app, nonce)
 
+        this.setHeaders(app, nonce)
         this.customServerMiddlewareLoader.loadCustomServerMiddleware(app)
         const sessionStore = new SessionStore(new IORedis(`${getEnvOrThrow("CACHE_SERVER")}`))
 
@@ -52,6 +53,7 @@ export default class ServerMiddlewareLoader {
             enabled: CSRF_ENABLED,
             sessionCookieName: getEnvOrThrow("COOKIE_NAME")
         })
+
         app.use(csrfProtectionMiddleware)
         this.nunjucks.configureNunjucks(app, directory, nonce)
     }

--- a/src/models/form/changeDetails.model.ts
+++ b/src/models/form/changeDetails.model.ts
@@ -5,4 +5,5 @@ export default interface ChangeDetailsFormModel {
   directorEmail?: string
   onBehalfName?: string
   onBehalfEmail?: string
+  _csrf?: string
 }

--- a/src/models/form/dissolutionApproval.model.ts
+++ b/src/models/form/dissolutionApproval.model.ts
@@ -8,4 +8,5 @@ export default interface DissolutionApprovalModel {
   officerType: OfficerType
   onBehalfName?: string
   date: string
+  _csrf?: string
 }

--- a/src/models/form/endorseCertificateFormModel.ts
+++ b/src/models/form/endorseCertificateFormModel.ts
@@ -1,3 +1,4 @@
 export default interface EndorseCertificateFormModel {
   confirmation?: string
+  _csrf?: string
 }

--- a/src/models/form/howDoYouWantToPay.model.ts
+++ b/src/models/form/howDoYouWantToPay.model.ts
@@ -2,4 +2,5 @@ import PaymentType from "../dto/paymentType.enum"
 
 export default interface HowDoYouWantToPayModel {
   paymentType?: PaymentType
+  _csrf?: string
 }

--- a/src/models/form/payByAccountDetails.model.ts
+++ b/src/models/form/payByAccountDetails.model.ts
@@ -1,4 +1,5 @@
 export default interface PayByAccountDetailsFormModel {
   presenterId?: string
   presenterAuthCode?: string
+  _csrf?: string
 }

--- a/src/models/form/searchCompany.model.ts
+++ b/src/models/form/searchCompany.model.ts
@@ -1,3 +1,4 @@
 export default interface SearchCompanyFormModel {
     companyNumber?: string
+    _csrf?: string
 }

--- a/src/models/form/selectDirector.model.ts
+++ b/src/models/form/selectDirector.model.ts
@@ -1,3 +1,4 @@
 export default interface SelectDirectorFormModel {
   director?: string
+  _csrf?: string
 }

--- a/src/models/form/selectSignatories.model.ts
+++ b/src/models/form/selectSignatories.model.ts
@@ -1,3 +1,4 @@
 export default interface SelectSignatoriesFormModel {
   signatories?: string[]
+  _csrf?:string
 }

--- a/src/models/form/whoToTell.model.ts
+++ b/src/models/form/whoToTell.model.ts
@@ -1,3 +1,4 @@
 export default interface WhoToTellFormModel {
   confirmation?: string
+  _csrf?: string
 }

--- a/src/schemas/changeDetails.schema.ts
+++ b/src/schemas/changeDetails.schema.ts
@@ -4,5 +4,12 @@ import { generateSchemaForSignatoryDetails } from "./signatoryDetails.schema"
 import OfficerType from "app/models/dto/officerType.enum"
 
 export default function defineSignatoryInfoSchema (officerType: OfficerType): Joi.ObjectSchema {
-    return Joi.object(generateSchemaForSignatoryDetails(officerType))
+    return Joi.object({
+        ...generateSchemaForSignatoryDetails(officerType),
+        _csrf: Joi.string()
+            .optional()
+            .messages({
+                "any.required": "There was a problem submitting your form"
+            })
+    })
 }

--- a/src/schemas/defineSignatoryInfo.schema.ts
+++ b/src/schemas/defineSignatoryInfo.schema.ts
@@ -18,7 +18,14 @@ function generateSchemaForSignatories (signatories: DirectorToSign[], officerTyp
 function generateSchemaForSignatory (signatory: DirectorToSign, officerType: OfficerType): Joi.SchemaMap {
     const formSuffix: string = `_${formatSignatoryId(signatory)}`
 
-    return generateSchemaForSignatoryDetails(officerType, formSuffix)
+    return {
+        ...generateSchemaForSignatoryDetails(officerType, formSuffix),
+        _csrf: Joi.string()
+            .optional()
+            .messages({
+                "any.required": "There was a problem submitting your form"
+            })
+    }
 }
 
 function formatSignatoryId (signatory: DirectorToSign): string {

--- a/src/schemas/endorseCertificate.schema.ts
+++ b/src/schemas/endorseCertificate.schema.ts
@@ -5,6 +5,11 @@ const formSchema = Joi.object({
         .required()
         .messages({
             "any.required": "Select to confirm that you have read and understood the statements."
+        }),
+    _csrf: Joi.string()
+        .optional()
+        .messages({
+            "any.required": "There was a problem submitting your form"
         })
 })
 

--- a/src/schemas/howDoYouWantToPay.schema.ts
+++ b/src/schemas/howDoYouWantToPay.schema.ts
@@ -12,5 +12,10 @@ export const howDoYouWantToPaySchema: Joi.ObjectSchema = Joi.object({
             "any.required": ERROR_MESSAGE,
             "any.only": ERROR_MESSAGE,
             "string.empty": ERROR_MESSAGE
+        }),
+    _csrf: Joi.string()
+        .optional()
+        .messages({
+            "any.required": "There was a problem submitting your form"
         })
 })

--- a/src/schemas/payByAccountDetails.schema.ts
+++ b/src/schemas/payByAccountDetails.schema.ts
@@ -15,6 +15,11 @@ const payByAccountDetailsSchema = Joi.object({
         .messages({
             "string.empty": emptyPresenterAuthCodeError,
             "any.required": emptyPresenterAuthCodeError
+        }),
+    _csrf: Joi.string()
+        .optional()
+        .messages({
+            "any.required": "There was a problem submitting your form"
         })
 })
 

--- a/src/schemas/searchCompany.schema.ts
+++ b/src/schemas/searchCompany.schema.ts
@@ -9,6 +9,11 @@ const formSchema = Joi.object({
             "string.empty": emptyCompanyNumberError,
             "string.max": "Company number does not exist or is incorrect",
             "any.required": emptyCompanyNumberError
+        }),
+    _csrf: Joi.string()
+        .optional()
+        .messages({
+            "any.required": "There was a problem submitting your form"
         })
 })
 

--- a/src/schemas/selectDirector.schema.ts
+++ b/src/schemas/selectDirector.schema.ts
@@ -10,6 +10,12 @@ export default function selectDirectorSchema (officerType: OfficerType): Joi.Obj
             .messages({
                 "any.required": `Select which of the ${officerType}s you are or if you're not a ${officerType}`,
                 "string.empty": `Select which of the ${officerType}s you are or if you're not a ${officerType}`
+            }),
+        _csrf: Joi.string()
+            .optional()
+            .messages({
+                "any.required": "There was a problem submitting your form"
             })
+
     })
 }

--- a/src/schemas/selectSignatories.schema.ts
+++ b/src/schemas/selectSignatories.schema.ts
@@ -12,6 +12,11 @@ export default function selectSignatoriesSchema (officerType: OfficerType, minSi
             .messages({
                 "any.required": `Select the ${officerType}s who will be signing the application.`,
                 "array.min": `Select more than half of the ${officerType}s to sign the application.`
+            }),
+        _csrf: Joi.string()
+            .optional()
+            .messages({
+                "any.required": "There was a problem submitting your form"
             })
     })
 }

--- a/src/schemas/whoToTell.schema.ts
+++ b/src/schemas/whoToTell.schema.ts
@@ -5,6 +5,11 @@ const formSchema = Joi.object({
         .required()
         .messages({
             "any.required": "You must agree to continue"
+        }),
+    _csrf: Joi.string()
+        .optional()
+        .messages({
+            "any.required": "There was a problem submitting your form"
         })
 })
 

--- a/src/views/change-details.njk
+++ b/src/views/change-details.njk
@@ -29,6 +29,7 @@
 
       <form method="post" novalidate>
 
+        {% include "components/csrf_token.njk" %}
         {% set formSuffix = "" %}
         {% include "components/define-signatory-info/signatory-details.njk" %}
 

--- a/src/views/check-your-answers.njk
+++ b/src/views/check-your-answers.njk
@@ -63,6 +63,9 @@
       {% endfor %}
 
       <form method="post">
+
+        {% include "components/csrf_token.njk" %}
+
         {{
           govukButton({
             text: 'Continue',

--- a/src/views/components/csrf_token.njk
+++ b/src/views/components/csrf_token.njk
@@ -1,0 +1,5 @@
+{{
+    csrfTokenInput({
+        csrfToken: csrfToken
+    })
+}}

--- a/src/views/define-signatory-info.njk
+++ b/src/views/define-signatory-info.njk
@@ -28,6 +28,9 @@
       }) }}
 
       <form method="post" novalidate>
+
+        {% include "components/csrf_token.njk" %}
+
         {% for signatory in signatories %}
           {% set formSuffix = "_" + (signatory.id | lower) %}
           {% set signatoryName = signatory.name %}

--- a/src/views/endorse-company-closure-certificate.njk
+++ b/src/views/endorse-company-closure-certificate.njk
@@ -42,7 +42,7 @@
 
       <p id="declaration-paragraph" class="govuk-body">I/We as {{ approvalModel.officerType }}s / the majority of
         {{ approvalModel.officerType }}s apply for this {{ approvalModel.officerType | asCompanyDisplayName }} to be
-        struck off the Register and declare that none of the circumstances described in  
+        struck off the Register and declare that none of the circumstances described in
           <a href="https://www.legislation.gov.uk/ukpga/2006/46/section/1004" target="_blank" class="govuk-link piwik-event" data-event-id="section-1004-companies-act-2006-link">section 1004 of the Companies Act 2006 (opens in a new tab)</a>
           or  <a href="https://www.legislation.gov.uk/ukpga/2006/46/section/1005" target="_blank" class="govuk-link piwik-event" data-event-id="section-1005-companies-act-2006-link">section 1005 of the Companies Act 2006 (opens in a new tab)</a>
            (being circumstances in which the {{ approvalModel.officerType }}s would otherwise be prohibited under those sections.)</p>
@@ -58,6 +58,9 @@
       <h2 class="govuk-heading-m">By ticking this box you are signing the application</h2>
 
       <form method="post">
+
+        {% include "components/csrf_token.njk" %}
+
         {{
           govukCheckboxes({
             idPrefix: "confirmation",

--- a/src/views/landing.njk
+++ b/src/views/landing.njk
@@ -20,18 +20,17 @@
         <li>to pay using a credit or debit card{% if payByAccountFeatureEnabled %}, or a Companies House account{% endif %}</li>
       </ul>
       <p class="govuk-body">You can also sign in to this service to download a copy of your application after it has been submitted.</p>
-      <form method="post">
-        {{
-          govukButton({
-            text: 'Start now',
-            isStartButton: true,
-            attributes: {
-              id: 'start-now',
-              'data-event-id': 'start-now-button' if piwik
-            }
-          })
-        }}
-      </form>
+      {{
+        govukButton({
+          text: "Start now",
+          href: redirectUrl,
+          isStartButton: true,
+          attributes: {
+            id: 'start-now',
+            'data-event-id': 'start-now-button' if piwik
+          }
+        })
+      }}
       <h2 class="govuk-heading-m">Before you start</h2>
       <p class="govuk-body-s">Read the <a class="piwik-event" data-event-id="eDS01-landing-page-guidance" href="https://www.gov.uk/government/publications/company-strike-off-dissolution-and-restoration/strike-off-dissolution-and-restoration" target="_blank" class="govuk-link">guidance for striking off and dissolving a company (opens in a new tab)</a>.</p>
     </div>

--- a/src/views/layout.njk
+++ b/src/views/layout.njk
@@ -4,6 +4,7 @@
 {% from 'govuk/components/footer/macro.njk'         import govukFooter %}
 {% from 'govuk/components/header/macro.njk'         import govukHeader %}
 {% from 'govuk/components/phase-banner/macro.njk'   import govukPhaseBanner %}
+{% from "web-security-node/components/csrf-token-input/macro.njk" import csrfTokenInput %}
 
 {% block head %}
   <!--[if !IE 8]><!-->
@@ -15,7 +16,7 @@
   <script src="https://code.jquery.com/jquery-1.12.4.min.js"
           integrity="sha256-ZosEbRLbNQzLpnKIkEdrPv7lOy9C27hHQ+Xp8a4MxAQ="
           crossorigin="anonymous"></script>
-  
+
   <script nonce={{ nonce | dump | safe }} type="application/javascript">
     window.SERVICE_NAME = 'dissolutions'
     window.PIWIK_URL = '{{ piwik.url }}'
@@ -51,6 +52,7 @@
 {% set mainClasses = mainClasses | default('govuk-main-wrapper--auto-spacing') %}
 
 {% block beforeContent %}
+
   <div id="templateName" data-id="{{ title }}" hidden></div>
 
   {{

--- a/src/views/layout.njk
+++ b/src/views/layout.njk
@@ -4,7 +4,7 @@
 {% from 'govuk/components/footer/macro.njk'         import govukFooter %}
 {% from 'govuk/components/header/macro.njk'         import govukHeader %}
 {% from 'govuk/components/phase-banner/macro.njk'   import govukPhaseBanner %}
-{% from "web-security-node/components/csrf-token-input/macro.njk" import csrfTokenInput %}
+{% from 'web-security-node/components/csrf-token-input/macro.njk' import csrfTokenInput %}
 
 {% block head %}
   <!--[if !IE 8]><!-->

--- a/src/views/pay-by-account-details.njk
+++ b/src/views/pay-by-account-details.njk
@@ -22,6 +22,9 @@
       <h1 class="govuk-heading-xl">Enter your details to pay by account</h1>
 
       <form method="post">
+
+        {% include "components/csrf_token.njk" %}
+
         {{
           govukInput({
             id: "presenter-id",

--- a/src/views/payment-review.njk
+++ b/src/views/payment-review.njk
@@ -7,6 +7,9 @@
 
 {% block content %}
   <form method="post">
+
+    {% include "components/csrf_token.njk" %}
+
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         <h1 class="govuk-heading-xl">Review your payment</h1>

--- a/src/views/search-company.njk
+++ b/src/views/search-company.njk
@@ -17,7 +17,7 @@
       href: backUri
     })
   }}
-  
+
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       {% include 'components/errors/error-summary.njk' %}
@@ -30,6 +30,9 @@
         was set up.
        </div>
       <form method="post">
+
+        {% include "components/csrf_token.njk" %}
+
         {{
           govukInput({
             describedBy: "company-number-hint",
@@ -40,23 +43,23 @@
             id: "company-number",
             name: "companyNumber",
             value: data.companyNumber
-          })   
+          })
         }}
 
-        {{  
+        {{
           govukDetails({
             summaryHtml: '<div class="piwik-event" data-event-id="help-with-company-number-link"> Help with company number</div>',
             html: '<p>You can find it using the <a href="https://beta.companieshouse.gov.uk/" class="govuk-link piwik-event" data-event-id="companieshouse-service-link" rel="noreferrer noopener" target="_blank">Companies House Service (opens in a new tab)</a>.</p>'
           })
         }}
 
-        {{ 
+        {{
           govukButton({
             text: 'Continue',
             attributes: {
               id: 'submit'
             }
-          }) 
+          })
         }}
       </form>
     </div>

--- a/src/views/select-director.njk
+++ b/src/views/select-director.njk
@@ -21,6 +21,9 @@
       {% include 'components/errors/error-summary.njk' %}
 
       <form method="post">
+
+        {% include "components/csrf_token.njk" %}
+
         {{
           govukRadios({
             idPrefix: "select-director",

--- a/src/views/select-signatories.njk
+++ b/src/views/select-signatories.njk
@@ -21,6 +21,9 @@
       {% include 'components/errors/error-summary.njk' %}
 
       <form method="post">
+
+        {% include "components/csrf_token.njk" %}
+
         {{
           govukCheckboxes({
             idPrefix: "signatories",

--- a/src/views/view-company-information.njk
+++ b/src/views/view-company-information.njk
@@ -91,6 +91,9 @@
         })
       }}
       <form method="post">
+
+        {% include "components/csrf_token.njk" %}
+
         {{
           govukButton({
             text: 'Confirm and continue',

--- a/src/views/who-to-tell.njk
+++ b/src/views/who-to-tell.njk
@@ -35,7 +35,10 @@
       }}
 
       <form method="post">
-        {{ 
+
+        {% include "components/csrf_token.njk" %}
+
+        {{
           govukCheckboxes({
             idPrefix: "confirmation",
             name: "confirmation",

--- a/test/__mocks__/csrfProtectionMiddleware.mock.ts
+++ b/test/__mocks__/csrfProtectionMiddleware.mock.ts
@@ -1,0 +1,9 @@
+const webSecurity = require("@companieshouse/web-security-node")
+const sinon = require("sinon")
+
+const mockCsrfMiddleware = sinon.createSandbox()
+mockCsrfMiddleware.replaceGetter(webSecurity, "CsrfProtectionMiddleware", (options: any) => (req: any, res: any, next: any) => {
+    return next()
+})
+
+export default mockCsrfMiddleware

--- a/test/controllers/accessibilityStatement.controller.test.ts
+++ b/test/controllers/accessibilityStatement.controller.test.ts
@@ -1,16 +1,16 @@
 import "reflect-metadata"
-
 import { expect } from "chai"
 import request from "supertest"
 import { createApp } from "./helpers/application.factory"
-
 import "app/controllers/accessibilityStatement.controller"
 import { ACCESSIBILITY_STATEMENT_URI } from "app/paths"
+import mockCsrfMiddleware from "test/__mocks__/csrfProtectionMiddleware.mock";
+
+mockCsrfMiddleware.restore()
 
 const pageHeading = "Accessibility statement for the Apply to strike off and dissolve a company service"
 
 describe("AccessibilityStatementController", () => {
-
     describe("GET request", () => {
         it("should match the heading when trying to access the page", async () => {
             const app = createApp()

--- a/test/controllers/applicationStatus.controller.test.ts
+++ b/test/controllers/applicationStatus.controller.test.ts
@@ -20,6 +20,9 @@ import { ViewApplicationStatus } from "app/models/view/viewApplicationStatus.mod
 import { APPLICATION_STATUS_URI, CHANGE_DETAILS_URI, WAIT_FOR_OTHERS_TO_SIGN_URI } from "app/paths"
 import DissolutionService from "app/services/dissolution/dissolution.service"
 import SessionService from "app/services/session/session.service"
+import mockCsrfMiddleware from "test/__mocks__/csrfProtectionMiddleware.mock";
+
+mockCsrfMiddleware.restore()
 
 describe("ApplicationStatusController", () => {
 

--- a/test/controllers/certificateDownload.controller.test.ts
+++ b/test/controllers/certificateDownload.controller.test.ts
@@ -12,6 +12,9 @@ import DissolutionSession from "app/models/session/dissolutionSession.model"
 import { CERTIFICATE_DOWNLOAD_URI } from "app/paths"
 import DissolutionService from "app/services/dissolution/dissolution.service"
 import SessionService from "app/services/session/session.service"
+import mockCsrfMiddleware from "test/__mocks__/csrfProtectionMiddleware.mock";
+
+mockCsrfMiddleware.restore()
 
 describe("CertificateDownloadController", () => {
 

--- a/test/controllers/certificateSigned.controller.test.ts
+++ b/test/controllers/certificateSigned.controller.test.ts
@@ -24,6 +24,9 @@ import {
     generateViewApplicationStatusModel,
     generateViewApplicationStatusSignatory
 } from "test/fixtures/viewApplicationStatus.fixtures"
+import mockCsrfMiddleware from "test/__mocks__/csrfProtectionMiddleware.mock";
+
+mockCsrfMiddleware.restore()
 
 let session: SessionService
 

--- a/test/controllers/changeDetails.controller.test.ts
+++ b/test/controllers/changeDetails.controller.test.ts
@@ -24,6 +24,9 @@ import { CHANGE_DETAILS_URI, WAIT_FOR_OTHERS_TO_SIGN_URI } from "app/paths"
 import DissolutionDirectorService from "app/services/dissolution/dissolutionDirector.service"
 import SessionService from "app/services/session/session.service"
 import FormValidator from "app/utils/formValidator.util"
+import mockCsrfMiddleware from "test/__mocks__/csrfProtectionMiddleware.mock";
+
+mockCsrfMiddleware.restore()
 
 describe("ChangeDetailsController", () => {
 

--- a/test/controllers/checkYourAnswers.controller.test.ts
+++ b/test/controllers/checkYourAnswers.controller.test.ts
@@ -18,6 +18,9 @@ import SessionService from "app/services/session/session.service"
 
 import { createApp } from "test/controllers/helpers/application.factory"
 import { generateDirectorToSign, generateDissolutionSession } from "test/fixtures/session.fixtures"
+import mockCsrfMiddleware from "test/__mocks__/csrfProtectionMiddleware.mock";
+
+mockCsrfMiddleware.restore()
 
 describe("CheckYourAnswersController", () => {
     let session: SessionService

--- a/test/controllers/defineSignatoryInfo.controller.test.ts
+++ b/test/controllers/defineSignatoryInfo.controller.test.ts
@@ -28,6 +28,9 @@ import {
 import SessionService from "app/services/session/session.service"
 import SignatoryService from "app/services/signatories/signatory.service"
 import FormValidator from "app/utils/formValidator.util"
+import mockCsrfMiddleware from "test/__mocks__/csrfProtectionMiddleware.mock";
+
+mockCsrfMiddleware.restore()
 
 describe("DefineSignatoryInfoController", () => {
 

--- a/test/controllers/endorseCompanyClosureCertificate.controller.test.ts
+++ b/test/controllers/endorseCompanyClosureCertificate.controller.test.ts
@@ -23,6 +23,9 @@ import FormValidator from "app/utils/formValidator.util"
 
 import { generateApprovalModel } from "test/fixtures/dissolutionApi.fixtures"
 import { generateDissolutionSession } from "test/fixtures/session.fixtures"
+import mockCsrfMiddleware from "test/__mocks__/csrfProtectionMiddleware.mock";
+
+mockCsrfMiddleware.restore()
 
 describe("EndorseCompanyClosureCertificateController", () => {
 

--- a/test/controllers/helpers/application.factory.ts
+++ b/test/controllers/helpers/application.factory.ts
@@ -34,7 +34,8 @@ export const createApp = (configureBindings?: (container: Container) => void): A
               [
                   "src/views",
                   "node_modules/govuk-frontend",
-                  "node_modules/govuk-frontend/components"
+                  "node_modules/govuk-frontend/components",
+                  "node_modules/@companieshouse"
               ],
               {
                   autoescape: true,

--- a/test/controllers/howDoYouWantToPay.controller.test.ts
+++ b/test/controllers/howDoYouWantToPay.controller.test.ts
@@ -26,6 +26,9 @@ import SessionService from "app/services/session/session.service"
 import FormValidator from "app/utils/formValidator.util"
 
 import { generateDissolutionGetResponse } from "test/fixtures/dissolutionApi.fixtures"
+import mockCsrfMiddleware from "test/__mocks__/csrfProtectionMiddleware.mock";
+
+mockCsrfMiddleware.restore()
 
 describe("HowDoYouWantToPayController", () => {
 

--- a/test/controllers/landing.controller.test.ts
+++ b/test/controllers/landing.controller.test.ts
@@ -1,13 +1,14 @@
 import "reflect-metadata"
-
 import { assert } from "chai"
 import { Application } from "express"
 import { StatusCodes } from "http-status-codes"
 import request from "supertest"
 import { createApp } from "./helpers/application.factory"
-
 import "app/controllers/landing.controller"
 import { ROOT_URI, WHO_TO_TELL_URI } from "app/paths"
+import mockCsrfMiddleware from "test/__mocks__/csrfProtectionMiddleware.mock";
+
+mockCsrfMiddleware.restore()
 
 const app: Application = createApp()
 
@@ -16,15 +17,7 @@ describe("LandingController", () => {
         it("should render the landing page", async () => {
             const res = await request(app).get(ROOT_URI).expect(StatusCodes.OK)
             assert.include(res.text, "Use this service to apply to close a public limited company, a private limited company, or a limited liability partnership (LLP).")
-        })
-    })
-
-    describe("POST request", () => {
-        it("should redirect to the who to tell screen upon submission", async () => {
-            await request(app)
-                .post(ROOT_URI)
-                .expect(StatusCodes.MOVED_TEMPORARILY)
-                .expect("Location", WHO_TO_TELL_URI)
+            assert.include(res.text, WHO_TO_TELL_URI)
         })
     })
 })

--- a/test/controllers/notSelectedSignatory.test.ts
+++ b/test/controllers/notSelectedSignatory.test.ts
@@ -23,6 +23,9 @@ import {
     generateViewApplicationStatusModel,
     generateViewApplicationStatusSignatory
 } from "test/fixtures/viewApplicationStatus.fixtures"
+import mockCsrfMiddleware from "test/__mocks__/csrfProtectionMiddleware.mock";
+
+mockCsrfMiddleware.restore()
 
 let session: SessionService
 let dissolutionService: DissolutionService

--- a/test/controllers/payByAccountDetails.controller.test.ts
+++ b/test/controllers/payByAccountDetails.controller.test.ts
@@ -28,6 +28,9 @@ import SessionService from "app/services/session/session.service"
 import TYPES from "app/types"
 import FormValidator from "app/utils/formValidator.util"
 import { generateDissolutionConfirmation } from "test/fixtures/session.fixtures"
+import mockCsrfMiddleware from "test/__mocks__/csrfProtectionMiddleware.mock";
+
+mockCsrfMiddleware.restore()
 
 describe("PayByAccountDetailsController", () => {
 

--- a/test/controllers/paymentReview.controller.test.ts
+++ b/test/controllers/paymentReview.controller.test.ts
@@ -21,6 +21,9 @@ import SessionService from "app/services/session/session.service"
 import TYPES from "app/types"
 
 import { generateDissolutionGetResponse } from "test/fixtures/dissolutionApi.fixtures"
+import mockCsrfMiddleware from "test/__mocks__/csrfProtectionMiddleware.mock";
+
+mockCsrfMiddleware.restore()
 
 describe("PaymentReviewController", () => {
 

--- a/test/controllers/redirect.controller.test.ts
+++ b/test/controllers/redirect.controller.test.ts
@@ -33,6 +33,9 @@ import SessionService from "app/services/session/session.service"
 
 import { generateApprovalModel, generateDissolutionGetResponse, generateGetDirector } from "test/fixtures/dissolutionApi.fixtures"
 import { generateDissolutionConfirmation, generateDissolutionSession } from "test/fixtures/session.fixtures"
+import mockCsrfMiddleware from "test/__mocks__/csrfProtectionMiddleware.mock";
+
+mockCsrfMiddleware.restore()
 
 describe("RedirectController", () => {
 

--- a/test/controllers/searchCompany.controller.test.ts
+++ b/test/controllers/searchCompany.controller.test.ts
@@ -22,6 +22,9 @@ import CompanyService from "app/services/company/company.service"
 import SessionService from "app/services/session/session.service"
 import CompanyNumberSanitizer from "app/utils/companyNumberSanitizer"
 import FormValidator from "app/utils/formValidator.util"
+import mockCsrfMiddleware from "test/__mocks__/csrfProtectionMiddleware.mock";
+
+mockCsrfMiddleware.restore()
 
 describe("SearchCompanyController", () => {
 

--- a/test/controllers/selectDirector.controller.test.ts
+++ b/test/controllers/selectDirector.controller.test.ts
@@ -30,6 +30,9 @@ import selectDirectorSchema from "app/schemas/selectDirector.schema"
 import CompanyOfficersService from "app/services/company-officers/companyOfficers.service"
 import SessionService from "app/services/session/session.service"
 import FormValidator from "app/utils/formValidator.util"
+import mockCsrfMiddleware from "test/__mocks__/csrfProtectionMiddleware.mock";
+
+mockCsrfMiddleware.restore()
 
 describe("SelectDirectorController", () => {
 

--- a/test/controllers/selectSignatories.controller.test.ts
+++ b/test/controllers/selectSignatories.controller.test.ts
@@ -29,6 +29,9 @@ import CompanyOfficersService from "app/services/company-officers/companyOfficer
 import SessionService from "app/services/session/session.service"
 import SignatoryService from "app/services/signatories/signatory.service"
 import FormValidator from "app/utils/formValidator.util"
+import mockCsrfMiddleware from "test/__mocks__/csrfProtectionMiddleware.mock";
+
+mockCsrfMiddleware.restore()
 
 describe("SelectSignatoriesController", () => {
 

--- a/test/controllers/viewCompanyInformation.controller.test.ts
+++ b/test/controllers/viewCompanyInformation.controller.test.ts
@@ -18,6 +18,9 @@ import SessionService from "app/services/session/session.service"
 
 import { generateCompanyDetails } from "test/fixtures/companyProfile.fixtures"
 import { generateDissolutionSession } from "test/fixtures/session.fixtures"
+import mockCsrfMiddleware from "test/__mocks__/csrfProtectionMiddleware.mock";
+
+mockCsrfMiddleware.restore()
 
 describe("ViewCompanyInformationController", () => {
 

--- a/test/controllers/viewFinalConfirmation.controller.test.ts
+++ b/test/controllers/viewFinalConfirmation.controller.test.ts
@@ -18,6 +18,9 @@ import DissolutionSession from "app/models/session/dissolutionSession.model"
 import { VIEW_FINAL_CONFIRMATION_URI } from "app/paths"
 import DissolutionService from "app/services/dissolution/dissolution.service"
 import SessionService from "app/services/session/session.service"
+import mockCsrfMiddleware from "test/__mocks__/csrfProtectionMiddleware.mock";
+
+mockCsrfMiddleware.restore()
 
 describe("ViewFinalConfirmationController", () => {
 

--- a/test/controllers/waitForOthersToSign.controller.test.ts
+++ b/test/controllers/waitForOthersToSign.controller.test.ts
@@ -23,6 +23,9 @@ import DissolutionService from "app/services/dissolution/dissolution.service"
 import SessionService from "app/services/session/session.service"
 
 import { generateDissolutionSession } from "test/fixtures/session.fixtures"
+import mockCsrfMiddleware from "test/__mocks__/csrfProtectionMiddleware.mock";
+
+mockCsrfMiddleware.restore()
 
 let session: SessionService
 let dissolutionService: DissolutionService

--- a/test/controllers/whoToTell.controller.test.ts
+++ b/test/controllers/whoToTell.controller.test.ts
@@ -12,6 +12,9 @@ import ValidationErrors from "app/models/view/validationErrors.model"
 import { SEARCH_COMPANY_URI, WHO_TO_TELL_URI } from "app/paths"
 import formSchema from "app/schemas/whoToTell.schema"
 import FormValidator from "app/utils/formValidator.util"
+import mockCsrfMiddleware from "test/__mocks__/csrfProtectionMiddleware.mock";
+
+mockCsrfMiddleware.restore()
 
 describe("WhoToTellController", () => {
     describe("GET - ensure that page loads correctly", () => {

--- a/test/fixtures/companyOfficers.fixtures.ts
+++ b/test/fixtures/companyOfficers.fixtures.ts
@@ -105,13 +105,15 @@ export function generateDirectorDetails (): DirectorDetails {
 
 export function generateSelectDirectorFormModel (director: string = "123"): SelectDirectorFormModel {
     return {
-        director
+        director,
+        _csrf: "abc123"
     }
 }
 
 export function generateSelectSignatoriesFormModel (...signatories: string[]): SelectSignatoriesFormModel {
     return {
-        signatories: signatories || ["123"]
+        signatories: signatories || ["123"],
+        _csrf: "abc123"
     }
 }
 
@@ -121,14 +123,16 @@ export function generateDefineSignatoryInfoFormModel (): DefineSignatoryInfoForm
         directorEmail_123abc: "director@mail.com",
         isSigning_456def: SignatorySigning.ON_BEHALF,
         onBehalfName_456def: "Mr Accountant",
-        onBehalfEmail_456def: "accountant@mail.com"
+        onBehalfEmail_456def: "accountant@mail.com",
+        _csrf: "abc123"
     }
 }
 
 export function generateWillSignChangeDetailsFormModel (): ChangeDetailsFormModel {
     return {
         isSigning: SignatorySigning.WILL_SIGN,
-        directorEmail: "director@mail.com"
+        directorEmail: "director@mail.com",
+        _csrf: "abc123"
     }
 }
 

--- a/test/fixtures/companyProfile.fixtures.ts
+++ b/test/fixtures/companyProfile.fixtures.ts
@@ -68,7 +68,8 @@ export function generateConfirmationStatement (): ConfirmationStatement {
 
 export function generateSearchCompanyForm (companyNumber: string = "1234"): SearchCompanyFormModel {
     return {
-        companyNumber
+        companyNumber,
+        _csrf: "abc123"
     }
 }
 

--- a/test/fixtures/payment.fixtures.ts
+++ b/test/fixtures/payment.fixtures.ts
@@ -75,7 +75,8 @@ function generatePaymentDetails (): PaymentDetails {
 export function generatePayByAccountDetailsForm (): PayByAccountDetailsFormModel {
     return {
         presenterId: "1234",
-        presenterAuthCode: "ABC123"
+        presenterAuthCode: "ABC123",
+        _csrf: "abc123"
     }
 }
 
@@ -94,6 +95,7 @@ export function generatePresenterAuthResponse (): PresenterAuthResponse {
 
 export function generateHowDoYouWantToPayForm (): HowDoYouWantToPayFormModel {
     return {
-        paymentType: PaymentType.CREDIT_DEBIT_CARD
+        paymentType: PaymentType.CREDIT_DEBIT_CARD,
+        _csrf: "abc123"
     }
 }

--- a/test/middleware/auth.middleware.test.ts
+++ b/test/middleware/auth.middleware.test.ts
@@ -7,7 +7,7 @@ import * as sinon from "sinon"
 import { instance, mock, when } from "ts-mockito"
 
 import AuthMiddleware from "app/middleware/auth.middleware"
-import { SEARCH_COMPANY_URI } from "app/paths"
+import { WHO_TO_TELL_URI } from "app/paths"
 import UriFactory from "app/utils/uri.factory"
 
 describe("AuthMiddleware", () => {
@@ -43,7 +43,7 @@ describe("AuthMiddleware", () => {
             returnUrl: "some-uri"
         }
 
-        when(uriFactory.createAbsoluteUri(req, SEARCH_COMPANY_URI)).thenReturn("some-uri")
+        when(uriFactory.createAbsoluteUri(req, WHO_TO_TELL_URI)).thenReturn("some-uri")
 
         middleware(req, res, next)
 

--- a/test/schemas/changeDetails.schema.test.ts
+++ b/test/schemas/changeDetails.schema.test.ts
@@ -31,9 +31,8 @@ describe("Change Details Schema", () => {
 
         it("should return no errors when data is valid", () => {
             form.directorEmail = "director@mail.com"
-
+            form._csrf = "abc123"
             const errors: ValidationResult = changeDetailsSchema(OfficerType.DIRECTOR).validate(form, { abortEarly: false })
-
             assert.isUndefined(errors.error)
         })
 

--- a/test/schemas/defineSignatoryInfo.schema.test.ts
+++ b/test/schemas/defineSignatoryInfo.schema.test.ts
@@ -41,6 +41,7 @@ describe("Define Signatory Info Schema", () => {
         form[`directorEmail_${SIGNATORY_2_ID_LOWER}`] = ""
         form[`onBehalfName_${SIGNATORY_2_ID_LOWER}`] = "Mr Accountant"
         form[`onBehalfEmail_${SIGNATORY_2_ID_LOWER}`] = "accountant@mail.com"
+        form._csrf = "abc123"
 
         const errors: ValidationResult = defineSignatoryInfoSchema([signatory1, signatory2], officerType).validate(form, { abortEarly: false })
 

--- a/test/schemas/endorseCertificate.schema.test.ts
+++ b/test/schemas/endorseCertificate.schema.test.ts
@@ -8,11 +8,10 @@ describe("Endorse Certificate Schema", () => {
 
     it("should return no errors when data is valid", () => {
         const validForm: EndorseCertificateFormModel = {
-            confirmation: "understdood"
+            confirmation: "understdood",
+            _csrf: "abc123"
         }
-
         const errors: ValidationResult = formSchema.validate(validForm)
-
         assert.isUndefined(errors.error)
     })
 

--- a/test/schemas/howDoYouWantToPay.schema.test.ts
+++ b/test/schemas/howDoYouWantToPay.schema.test.ts
@@ -11,9 +11,7 @@ describe("How do you want to pay Schema", () => {
     it("should return no errors when data is valid", () => {
         const validForm: HowDoYouWantToPayForm = generateHowDoYouWantToPayForm()
         validForm.paymentType = PaymentType.ACCOUNT
-
         const errors: ValidationResult = howDoYouWantToPaySchema.validate(validForm)
-
         assert.isUndefined(errors.error)
     })
 

--- a/test/schemas/payByAccountDetails.schema.test.ts
+++ b/test/schemas/payByAccountDetails.schema.test.ts
@@ -8,9 +8,7 @@ import payByAccountDetailsSchema from "app/schemas/payByAccountDetails.schema"
 describe("Pay By Account Schema", () => {
     it("should return no errors when data is valid", () => {
         const validForm: PayByAccountDetailsFormModel = generatePayByAccountDetailsForm()
-
         const errors: ValidationResult = payByAccountDetailsSchema.validate(validForm)
-
         assert.isUndefined(errors.error)
     })
 

--- a/test/schemas/searchCompany.schema.test.ts
+++ b/test/schemas/searchCompany.schema.test.ts
@@ -8,9 +8,7 @@ import searchCompanySchema from "app/schemas/searchCompany.schema"
 describe("Search Company Schema", () => {
     it("should return no errors when data is valid", () => {
         const validForm: SearchCompanyFormModel = generateSearchCompanyForm("123")
-
         const errors: ValidationResult = searchCompanySchema.validate(validForm)
-
         assert.isUndefined(errors.error)
     })
 

--- a/test/schemas/selectDirector.schema.test.ts
+++ b/test/schemas/selectDirector.schema.test.ts
@@ -10,9 +10,7 @@ describe("Select Director Schema", () => {
 
     it("should return no errors when data is valid", () => {
         const validForm: SelectDirectorFormModel = generateSelectDirectorFormModel("123")
-
         const errors: ValidationResult = selectDirectorSchema(OfficerType.DIRECTOR).validate(validForm)
-
         assert.isUndefined(errors.error)
     })
 

--- a/test/schemas/selectSignatories.schema.test.ts
+++ b/test/schemas/selectSignatories.schema.test.ts
@@ -10,9 +10,7 @@ describe("Select Signatories Schema", () => {
 
     it("should return no errors when data is valid", () => {
         const validForm: SelectSignatoriesFormModel = generateSelectSignatoriesFormModel("123")
-
         const errors: ValidationResult = selectSignatoriesSchema(OfficerType.DIRECTOR, 1).validate(validForm)
-
         assert.isUndefined(errors.error)
     })
 

--- a/test/schemas/whoToTell.schema.test.ts
+++ b/test/schemas/whoToTell.schema.test.ts
@@ -8,20 +8,17 @@ describe("Who To Tell Schema", () => {
 
     it("should return no errors when data is valid", () => {
         const validForm: WhoToTellFormModel = {
-            confirmation: "understdood"
+            confirmation: "understdood",
+            _csrf: "abc123"
         }
-
         const errors: ValidationResult = formSchema.validate(validForm)
-
         assert.isUndefined(errors.error)
     })
 
     it("should return errors when data has missing properties", () => {
         const validForm: WhoToTellFormModel = {
         }
-
         const errors: ValidationResult = formSchema.validate(validForm)
-
         assert.deepEqual(errors.value, {})
         assert.equal(errors.error!.details.length, 1)
         assert.equal(errors.error!.details[0].context!.key, "confirmation")

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,8 +2,8 @@
     "compilerOptions": {
       "module": "commonjs",
       "strict": true,
-      "noUnusedLocals": true,
-      "noUnusedParameters": true,
+      "noUnusedLocals": false,
+      "noUnusedParameters": false,
       "noImplicitReturns": true,
       "noFallthroughCasesInSwitch": true,
       "pretty": true,


### PR DESCRIPTION
## Description

Implements CSRF tokens on web page journey for dissolution-web service

## Jira Ticket

[https://companieshouse.atlassian.net/browse/SEC-65](https://companieshouse.atlassian.net/browse/SEC-65)

## Coding Standards

Code Style Guide: https://github.com/companieshouse/dissolution-web/wiki/Code-Style-Guide

## Checklist

- [ ] 3 Amigos
- [ ] Acceptance Criteria met
- [ ] Branch named {feature|hotfix|task}/{S4-*}
- [ ] Commit messages are meaningful
- [ ] Manually tested
- [ ] All unit tests passing
- [ ] WAVE accessibility testing tool ran on new or updated pages
- [ ] All UI Tests Passing
- [ ] Pulled latest master into feature branch
- [ ] Sonar Analysis
- [ ] Master branch on Rebel1 and CIDev CI/CD pipeline is green
- [ ] Any Docker environment variables added are consistent with those on our upstream environments (Rebel1, CIDev etc)
- [ ] If your pull request depends on any other, please link them in the description

## Screenshots of new or updated views
