### PR TITLE
fix: resolve define signatory info view not seeing changed details

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8957,9 +8957,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash.camelcase": {

--- a/src/controllers/changeDetails.controller.ts
+++ b/src/controllers/changeDetails.controller.ts
@@ -152,9 +152,13 @@ export class ChangeDetailsController extends BaseController {
         defineSignatoryInfoFormModel: DefineSignatoryInfoFormModel,
         changeDetailsFormModel: ChangeDetailsFormModel
     ): DefineSignatoryInfoFormModel {
-        const directorEmailKey = `directorEmail_${signatoryId}`
-        const onBehalfNameKey = `onBehalfName_${signatoryId}`
-        const onBehalfEmailKey = `onBehalfEmail_${signatoryId}`
+
+        // The define-signatory-info view lowers the id's in the view...
+        const id = signatoryId.toLowerCase()
+
+        const directorEmailKey = `directorEmail_${id}`
+        const onBehalfNameKey = `onBehalfName_${id}`
+        const onBehalfEmailKey = `onBehalfEmail_${id}`
 
         const isOnBehalf = !!defineSignatoryInfoFormModel[onBehalfNameKey] && defineSignatoryInfoFormModel[onBehalfNameKey] !== ""
 

--- a/test/controllers/changeDetails.controller.test.ts
+++ b/test/controllers/changeDetails.controller.test.ts
@@ -29,7 +29,7 @@ describe("ChangeDetailsController", () => {
     let session: SessionService
     let directorService: DissolutionDirectorService
 
-    const SIGNATORY_ID = "abc123"
+    const SIGNATORY_ID = "aBc123"
 
     beforeEach(() => {
         session = mock(SessionService)
@@ -349,7 +349,7 @@ describe("ChangeDetailsController", () => {
                 .withSignatoryIdToEdit(SIGNATORY_ID)
                 .withDirectorToSign(aDirectorToSign().withId(SIGNATORY_ID).withEmail("director@mail.com").withName("Mr Accountant"))
                 .withDefineSignatoryInfoForm({
-                    [`directorEmail_${SIGNATORY_ID}`]: "old@mail.com",
+                    [`directorEmail_${SIGNATORY_ID.toLowerCase()}`]: "old@mail.com",
                 })
                 .withIsFromCheckAnswers(true)
                 .withSignatoryToEdit(aDissolutionGetDirector().withName("Mr Accountant").build())
@@ -372,12 +372,12 @@ describe("ChangeDetailsController", () => {
             assert.equal(res.status, StatusCodes.MOVED_TEMPORARILY)
             assert.equal(res.header.location, CHECK_YOUR_ANSWERS_URI)
             const updatedDefineSignatoryInfoForm = dissolutionSession.defineSignatoryInfoForm!
-            assert.equal(updatedDefineSignatoryInfoForm[`directorEmail_${SIGNATORY_ID}`], updatedEmail)
-            assert.isUndefined(updatedDefineSignatoryInfoForm[`onBehalfName_${SIGNATORY_ID}`])
-            assert.isUndefined(updatedDefineSignatoryInfoForm[`onBehalfEmail_${SIGNATORY_ID}`])
+            assert.equal(updatedDefineSignatoryInfoForm[`directorEmail_${SIGNATORY_ID.toLowerCase()}`], updatedEmail)
+            assert.isUndefined(updatedDefineSignatoryInfoForm[`onBehalfName_${SIGNATORY_ID.toLowerCase()}`])
+            assert.isUndefined(updatedDefineSignatoryInfoForm[`onBehalfEmail_${SIGNATORY_ID.toLowerCase()}`])
         })
 
-        it("should update the signatory in session and redirect to the check your answers screen if validation passes for a corporate director", async () => {
+        it("should update the signatory info in session and redirect to the check your answers screen if validation passes for a corporate director", async () => {
             const isFromCheckAnswers = true
             const updatedName = "Mr Accountant Updated"
             const updatedEmail = "updated.accountant@mail.com"
@@ -386,8 +386,8 @@ describe("ChangeDetailsController", () => {
                 .withSignatoryIdToEdit(SIGNATORY_ID)
                 .withDirectorToSign(aDirectorToSign().withId(SIGNATORY_ID).withEmail("director@mail.com").withOnBehalfName("Mr Accountant"))
                 .withDefineSignatoryInfoForm({
-                    [`onBehalfName_${SIGNATORY_ID}`]: "oldName",
-                    [`onBehalfEmail_${SIGNATORY_ID}`]: "old@mail.com"
+                    [`onBehalfName_${SIGNATORY_ID.toLowerCase()}`]: "oldName",
+                    [`onBehalfEmail_${SIGNATORY_ID.toLowerCase()}`]: "old@mail.com"
                 })
                 .withIsFromCheckAnswers(isFromCheckAnswers)
                 .withSignatoryToEdit(aDissolutionGetDirector().withOnBehalfName("Mr Accountant").build())
@@ -412,9 +412,9 @@ describe("ChangeDetailsController", () => {
             assert.equal(res.status, StatusCodes.MOVED_TEMPORARILY)
             assert.equal(res.header.location, CHECK_YOUR_ANSWERS_URI)
             const updatedDefineSignatoryInfoForm = dissolutionSession.defineSignatoryInfoForm!
-            assert.equal(updatedDefineSignatoryInfoForm[`onBehalfName_${SIGNATORY_ID}`], updatedName)
-            assert.equal(updatedDefineSignatoryInfoForm[`onBehalfEmail_${SIGNATORY_ID}`], updatedEmail)
-            assert.isUndefined(updatedDefineSignatoryInfoForm[`directorEmail_${SIGNATORY_ID}`])
+            assert.equal(updatedDefineSignatoryInfoForm[`onBehalfName_${SIGNATORY_ID.toLowerCase()}`], updatedName)
+            assert.equal(updatedDefineSignatoryInfoForm[`onBehalfEmail_${SIGNATORY_ID.toLowerCase()}`], updatedEmail)
+            assert.isUndefined(updatedDefineSignatoryInfoForm[`directorEmail_${SIGNATORY_ID.toLowerCase()}`])
         })
 
         it("should return a 404 if isFromCheckAnswers is true and no signatories in session", async () => {


### PR DESCRIPTION
## Description

This pull request standardizes the handling of signatory IDs by ensuring they are always converted to lowercase when used as keys in the `defineSignatoryInfoForm` object. This change affects both the controller logic and the related unit tests, ensuring consistency and preventing potential mismatches caused by case sensitivity.

## Jira Ticket

[fs-321](https://companieshouse.atlassian.net/browse/FS-312)
