### PR TITLE
feat: update error message for select director full name

### DIFF
--- a/src/schemas/selectDirector.schema.ts
+++ b/src/schemas/selectDirector.schema.ts
@@ -34,7 +34,7 @@ export default function selectDirectorSchema (officerType: OfficerType, director
             const fieldSchema = Joi.string()
                 .when("director", {
                     is: d.id,
-                    then: onBehalfNameValidationSchema(officerType),
+                    then: onBehalfNameValidationSchema(),
                     otherwise: Joi.string().allow("").optional()
                 })
 
@@ -44,15 +44,15 @@ export default function selectDirectorSchema (officerType: OfficerType, director
     return schema
 }
 
-function onBehalfNameValidationSchema(officerType: OfficerType) {
+function onBehalfNameValidationSchema() {
     return Joi.string()
         .required()
         .max(250)
         .pattern(/\S/, { name: "non-whitespace" })
         .messages({
-            "any.required": `Enter the name of the authorised person who will sign on behalf of the corporate ${officerType}`,
-            "string.empty": `Enter the name of the authorised person who will sign on behalf of the corporate ${officerType}`,
-            "string.max": `Name of authorised person signing must be 250 characters or less`,
-            "string.pattern.name": `Enter the name of the authorised person who will sign on behalf of the corporate ${officerType}`
+            "any.required": `Enter your full name`,
+            "string.empty": `Enter your full name`,
+            "string.max": `Full name must be 250 characters or less`,
+            "string.pattern.name": `Enter your full name`
         })
 }

--- a/test/schemas/selectDirector.schema.test.ts
+++ b/test/schemas/selectDirector.schema.test.ts
@@ -90,49 +90,49 @@ describe("Select Director Schema", () => {
             scenario: "undefined name",
             form: aSelectDirectorFormModel().withDirector("abc123").withOnBehalfName("abc123", undefined).build(),
             officerType: OfficerType.DIRECTOR,
-            expectedError: "Enter the name of the authorised person who will sign on behalf of the corporate director"
+            expectedError: "Enter your full name"
         },
         {
             scenario: "undefined name",
             form: aSelectDirectorFormModel().withDirector("abc123").withOnBehalfName("abc123", undefined).build(),
             officerType: OfficerType.MEMBER,
-            expectedError: "Enter the name of the authorised person who will sign on behalf of the corporate member"
+            expectedError: "Enter your full name"
         },
         {
             scenario: "empty name",
             form: aSelectDirectorFormModel().withDirector("abc123").withOnBehalfName("abc123", "").build(),
             officerType: OfficerType.DIRECTOR,
-            expectedError: "Enter the name of the authorised person who will sign on behalf of the corporate director"
+            expectedError: "Enter your full name"
         },
         {
             scenario: "empty name",
             form: aSelectDirectorFormModel().withDirector("abc123").withOnBehalfName("abc123", "").build(),
             officerType: OfficerType.MEMBER,
-            expectedError: "Enter the name of the authorised person who will sign on behalf of the corporate member"
+            expectedError: "Enter your full name"
         },
         {
             scenario: "empty whitespace name",
             form: aSelectDirectorFormModel().withDirector("abc123").withOnBehalfName("abc123", "   ").build(),
             officerType: OfficerType.DIRECTOR,
-            expectedError: "Enter the name of the authorised person who will sign on behalf of the corporate director"
+            expectedError: "Enter your full name"
         },
         {
             scenario: "empty whitespace name",
             form: aSelectDirectorFormModel().withDirector("abc123").withOnBehalfName("abc123", "   ").build(),
             officerType: OfficerType.MEMBER,
-            expectedError: "Enter the name of the authorised person who will sign on behalf of the corporate member"
+            expectedError: "Enter your full name"
         },
         {
             scenario: "name too long",
             form: aSelectDirectorFormModel().withDirector("abc123").withOnBehalfName("abc123", "X".repeat(251)).build(),
             officerType: OfficerType.DIRECTOR,
-            expectedError: "Name of authorised person signing must be 250 characters or less"
+            expectedError: "Full name must be 250 characters or less"
         },
         {
             scenario: "name too long",
             form: aSelectDirectorFormModel().withDirector("abc123").withOnBehalfName("abc123", "X".repeat(251)).build(),
             officerType: OfficerType.MEMBER,
-            expectedError: "Name of authorised person signing must be 250 characters or less"
+            expectedError: "Full name must be 250 characters or less"
         },
     ]
 


### PR DESCRIPTION
## Description

This pull request updates the validation and error messaging for the "on behalf name" field in the `selectDirectorSchema`. The main change is to standardize the validation error messages to a more generic "Enter your full name", regardless of the officer type, and to simplify the validation logic.

## Jira Ticket

[fs-249](https://companieshouse.atlassian.net/browse/FS-249)