### PR TITLE
increase maximum number of officers displayed

### DIFF
--- a/src/services/clients/companyOfficers.client.ts
+++ b/src/services/clients/companyOfficers.client.ts
@@ -14,6 +14,6 @@ export default class CompanyOfficersClient {
     public async getCompanyOfficers (token: string, companyNumber: string): Promise<Resource<CompanyOfficers>> {
         return this.factory
             .getCompanyOfficersService(token)
-            .getCompanyOfficers(companyNumber)
+            .getCompanyOfficers(companyNumber, 150)
     }
 }

--- a/test/services/clients/companyOfficers.client.test.ts
+++ b/test/services/clients/companyOfficers.client.test.ts
@@ -29,7 +29,7 @@ describe("CompanyOfficersClient", () => {
         it("should fetch and return the company officers for the provided company number", async () => {
             const response: Resource<CompanyOfficers> = generateCompanyOfficersResource()
 
-            when(companyOfficersService.getCompanyOfficers(COMPANY_NUMBER)).thenResolve(response)
+            when(companyOfficersService.getCompanyOfficers(COMPANY_NUMBER, 150)).thenResolve(response)
             when(factory.getCompanyOfficersService(TOKEN)).thenReturn(instance(companyOfficersService))
 
             const result: Resource<CompanyOfficers> = await companyOfficersClient.getCompanyOfficers(TOKEN, COMPANY_NUMBER)


### PR DESCRIPTION
## Description

Increase maximum number of officers that can be displayed to 150. Defaults to 35 if the parameter is not provided.

## Jira Ticket

Please add link to Jira ticket

## Coding Standards

Code Style Guide: https://github.com/companieshouse/dissolution-web/wiki/Code-Style-Guide

## Checklist

- [ ] 3 Amigos
- [ ] Acceptance Criteria met
- [ ] Branch named {feature|hotfix|task}/{S4-*}
- [ ] Commit messages are meaningful
- [ ] Manually tested
- [ ] All unit tests passing
- [ ] WAVE accessibility testing tool ran on new or updated pages
- [ ] All UI Tests Passing
- [ ] Pulled latest master into feature branch
- [ ] Sonar Analysis
- [ ] Master branch on Rebel1 and CIDev CI/CD pipeline is green
- [ ] Any Docker environment variables added are consistent with those on our upstream environments (Rebel1, CIDev etc)
- [ ] If your pull request depends on any other, please link them in the description

## Screenshots of new or updated views
