### PR TITLE
fix: validation and styling fixes for application-status

### DIFF
--- a/src/schemas/resendEmail.schema.ts
+++ b/src/schemas/resendEmail.schema.ts
@@ -3,7 +3,7 @@ import * as Joi from "@hapi/joi"
 export default function resendEmailSchema (): Joi.ObjectSchema {
     return Joi.object().keys({
         signatoryId: Joi.string()
-            .pattern(/^[A-Za-z0-9-]{1,50}$/)
+            .pattern(/^[A-Za-z0-9_-]{1,50}$/)
             .required()
             .messages({
                 "string.pattern.base": `Invalid signatory specified`

--- a/src/views/components/resend-email-cell.njk
+++ b/src/views/components/resend-email-cell.njk
@@ -8,7 +8,7 @@
       {{ csrfTokenInput({ csrfToken: csrfToken }) }}
 
       <input type="hidden" name="signatoryId" value="{{ signatory.id }}">
-      <button type="submit" id="resend-button-{{ index }}" class="govuk-link resend-link" data-event-id="resend-email-link">
+      <button type="submit" id="resend-button-{{ index }}" class="govuk-link govuk-button--link" data-event-id="resend-email-link">
         Resend email
       </button>
     </form>

--- a/src/views/components/view-application-status.njk
+++ b/src/views/components/view-application-status.njk
@@ -3,27 +3,6 @@
 
 {% from "components/resend-email-cell.njk" import resendEmailCell %}
 
-<style>
-  .resend-link {
-    background-color: transparent;
-    -webkit-appearance: none;
-    appearance: none;
-    box-shadow: none;
-    border: 0;
-    padding: 0;
-    color: #1d70b8;
-    text-decoration: underline;
-    cursor: pointer;
-    display: inline;
-  }
-
-  .resend-link:focus-visible {
-    /* keep a visible, text-only focus indicator */
-    text-decoration-thickness: 2px;
-    text-underline-offset: 2px;
-  }
-</style>
-
 <div class="govuk-grid-row govuk-!-margin-top-4">
   <div class="govuk-grid-column-two-thirds">
     <h2 class="govuk-heading-l">Application status</h2>

--- a/test/controllers/applicationStatus.controller.test.ts
+++ b/test/controllers/applicationStatus.controller.test.ts
@@ -125,6 +125,36 @@ describe("ApplicationStatusController", () => {
             })
         })
 
+        const validSignatoryIds: Array<any> = [
+            { signatoryId: "a" },
+            { signatoryId: "A1-9" },
+            { signatoryId: "abc-123" },
+            { signatoryId: "a".repeat(50) }, // max length
+            { signatoryId: "Z9-xyz-987" },
+            { signatoryId: "yK7psNr-W-lF68mo2n7fs_q8Gw"}
+        ]
+
+        validSignatoryIds.forEach((body) => {
+            it(`accepts valid signatory id: ${JSON.stringify(body)}`, async () => {
+                const id = body.signatoryId
+                const dissolutionSession = aDissolutionSession().build()
+                const signatoryEmail = "signatory@mail.com"
+
+                when(sessionService.requireDissolutionCompanyNumber(anything())).thenReturn(dissolutionSession.companyNumber!)
+                when(dissolutionService.getDissolutionSignatoryEmail(anything(), dissolutionSession.companyNumber!, id)).thenResolve(signatoryEmail)
+                when(dissolutionService.sendEmailNotification(dissolutionSession.companyNumber!, signatoryEmail)).thenResolve(true)
+
+                await request(app)
+                    .post(`${APPLICATION_STATUS_URI}/send-email`)
+                    .send(body)
+                    .expect(StatusCodes.MOVED_TEMPORARILY)
+                    .expect("Location", WAIT_FOR_OTHERS_TO_SIGN_URI)
+
+                verify(dissolutionService.sendEmailNotification(dissolutionSession.companyNumber!, signatoryEmail)).once()
+                verify(sessionService.updateRemindDirectorList(anything(), id, true)).once()
+            })
+        })
+
         const invalidSignatoryIds: Array<any> = [
             {},
             { signatoryId: " " },

--- a/test/controllers/applicationStatus.controller.test.ts
+++ b/test/controllers/applicationStatus.controller.test.ts
@@ -135,7 +135,7 @@ describe("ApplicationStatusController", () => {
         ]
 
         validSignatoryIds.forEach((body) => {
-            it(`accepts valid signatory id: ${JSON.stringify(body)}`, async () => {
+            it(`accepts valid signatory id: ${JSON.stringify(body)}`, async () => { // NOSONAR
                 const id = body.signatoryId
                 const dissolutionSession = aDissolutionSession().build()
                 const signatoryEmail = "signatory@mail.com"


### PR DESCRIPTION
## Description

This pull request improves the handling and validation of signatory IDs for the resend email functionality and aligns the button styling with GOV.UK standards. The main changes include updating the validation schema, enhancing test coverage, and improving the consistency of UI components.

**Validation and Testing Improvements:**
- Updated the `signatoryId` validation in `resendEmailSchema` to allow underscores (`_`) in addition to hyphens and alphanumeric characters, making the pattern `/^[A-Za-z0-9_-]{1,50}$/` ([[src/schemas/resendEmail.schema.tsL6-R6](diffhunk://#diff-afaca3af1908eef0ceb5820273b1bb38b84296e94e9f93ea876db91db61a80a0L6-R6)]).
- Added new test cases in `applicationStatus.controller.test.ts` to verify that signatory IDs containing underscores and other valid patterns are accepted ([[test/controllers/applicationStatus.controller.test.tsR128-R157](diffhunk://#diff-e21cd1060a3d227c9a402e8b0ac4efae14908e489da044bd50191c7c1f74a0e1R128-R157)]).

**UI Consistency and Styling:**
- Changed the resend email button in `resend-email-cell.njk` to use the `govuk-button--link` class for consistent styling with GOV.UK Design System components ([[src/views/components/resend-email-cell.njkL11-R11](diffhunk://#diff-61ac15a81b37d164a75f3ee285ba4c3823fbdfe328e6b2af3a6d59e0eb6fcf1dL11-R11)]).
- Removed custom CSS for `.resend-link` from `view-application-status.njk`, relying instead on the standardized GOV.UK button styles ([[src/views/components/view-application-status.njkL6-L26](diffhunk://#diff-dc7bdfef5adac767285133796582ee8d67b686c0e8b348c6dc0d784641287ddaL6-L26)]).

## Jira Ticket

fs-344(https://companieshouse.atlassian.net/browse/FS-344)