### PR TITLE
feat: content updates to provide director email address page

### DIFF
--- a/src/views/define-signatory-info.njk
+++ b/src/views/define-signatory-info.njk
@@ -6,13 +6,23 @@
 {% from "govuk/components/back-link/macro.njk"      import govukBackLink %}
 {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 
-{% set title = "Provide " + officerType + "s' email addresses - " + pageTitleSuffix %}
+{% if isMultiDirector %}
+  {% set title = "Provide " + officerType + "s' email addresses - " + pageTitleSuffix %}
+  {% set heading = "Provide " + officerType + "s' email addresses" %}
+  {% set bodyText = "We'll email each " + officerType + " you've selected, to ask them to sign the application online." %}
+  {% set backLinkHref = journeyPath(Paths.SELECT_SIGNATORIES_URI) %}
+{% else %}
+  {% set title = "Provide the " + officerType + "'s email address - " + pageTitleSuffix %}
+  {% set heading = "Provide the " + officerType + "'s email address" %}
+  {% set bodyText = "We'll email the " + officerType + " to ask them to sign the application online." %}
+  {% set backLinkHref = journeyPath(Paths.SELECT_DIRECTOR_URI) %}
+{% endif %}
 
 {% block content %}
   {{
     govukBackLink({
       text: "Back",
-      href: journeyPath(Paths.SELECT_SIGNATORIES_URI) if isMultiDirector else journeyPath(Paths.SELECT_DIRECTOR_URI)
+      href: backLinkHref
     })
   }}
 
@@ -20,9 +30,9 @@
     <div class="govuk-grid-column-two-thirds">
       {% include 'components/errors/error-summary.njk' %}
 
-      <h1 class="govuk-heading-xl">Provide {{ officerType }}s' email addresses</h1>
+      <h1 class="govuk-heading-xl">{{ heading }}</h1>
 
-      <p class="govuk-body">We'll email each {{ officerType }} you've selected, to ask them to sign the application online.</p>
+      <p class="govuk-body">{{ bodyText }}</p>
 
       <form method="post" novalidate>
 

--- a/test/controllers/defineSignatoryInfo.controller.test.ts
+++ b/test/controllers/defineSignatoryInfo.controller.test.ts
@@ -80,28 +80,47 @@ describe("DefineSignatoryInfoController", () => {
 
         const expectedContentCases = [
             {
-                description: "DS01 journey",
+                description: "DS01 - multi director",
                 officerType: OfficerType.DIRECTOR,
+                isMultiDirector: true,
                 expectedPageHeading: "Provide directors' email addresses",
                 expectedExplanatoryText: "We'll email each director you've selected, to ask them to sign the application online."
             },
             {
-                description: "LLDS01 journey",
+                description: "DS01 - single director",
+                officerType: OfficerType.DIRECTOR,
+                isMultiDirector: false,
+                expectedPageHeading: "Provide the director's email address",
+                expectedExplanatoryText: "We'll email the director to ask them to sign the application online."
+            },
+            {
+                description: "LLDS01 - multi member",
                 officerType: OfficerType.MEMBER,
+                isMultiDirector: true,
                 expectedPageHeading: "Provide members' email addresses",
                 expectedExplanatoryText: "We'll email each member you've selected, to ask them to sign the application online."
+            },
+            {
+                description: "LLDS01 - single member",
+                officerType: OfficerType.MEMBER,
+                isMultiDirector: false,
+                expectedPageHeading: "Provide the member's email address",
+                expectedExplanatoryText: "We'll email the member to ask them to sign the application online."
             }
         ]
 
         expectedContentCases.forEach((testCase) => {
-            it(`should render the select signatories page with correct static content for ${testCase.description}`, async () => {
+            it(`should render the define signatory info page with correct static content for ${testCase.description}`, async () => {
                 const {
                     officerType,
+                    isMultiDirector,
                     expectedPageHeading,
                     expectedExplanatoryText
                 } = testCase
 
-                when(session.getDissolutionSession(anything())).thenReturn(aDissolutionSession().withOfficerType(officerType).build())
+                when(session.getDissolutionSession(anything())).thenReturn(
+                    aDissolutionSession().withOfficerType(officerType).withIsMultiDirector(isMultiDirector).build()
+                )
 
                 const app = initApp()
 


### PR DESCRIPTION
## Description

This pull request improves the logic and content rendering for the "define signatory info" page, making the displayed text and navigation more accurate depending on whether there are multiple or single signatories (directors or members). The changes also expand and refine the corresponding tests to ensure correct behavior for all scenarios.

Content and logic improvements in the view:

* Updated `src/views/define-signatory-info.njk` to set the page title, heading, body text, and back link dynamically based on whether there are multiple or a single signatory, ensuring correct singular/plural and officer type usage.

Test coverage enhancements:

* Expanded test cases in `test/controllers/defineSignatoryInfo.controller.test.ts` to separately cover all combinations of officer type (director/member) and single vs. multiple signatories, verifying that the correct content and navigation are rendered for each scenario.

## Jira Ticket

[fs-287](https://companieshouse.atlassian.net/browse/FS-287)
