### PR TITLE
fix (FS-347): Update the presentation of the corporate director authorisation message

### DIFF
--- a/src/views/components/select-director-radios.njk
+++ b/src/views/components/select-director-radios.njk
@@ -8,6 +8,7 @@
 #}
 
 {% macro selectDirectorRadios(directors, data, errors, officerType) %}
+  {% set hintText = "You must be authorised by this corporate " + officerType + " to sign the application on its behalf." %}
   {% set items = [] %}
   {% for director in directors %}
     {% set onBehalfNameId = "on-behalf-name_" + director.id %}
@@ -19,7 +20,6 @@
         id: onBehalfNameId,
         name: onBehalfNameName,
         label: { text: "What is your full name?" },
-        hint: { text: "You must be authorised by this corporate director to sign the application on its behalf." },
         classes: "govuk-!-width-full",
         value: data[onBehalfNameName] if data,
         errorMessage: { text: errors[onBehalfNameName] } if errors[onBehalfNameName]
@@ -31,6 +31,7 @@
       text: director.name,
       checked: data.director == director.id,
       attributes: { "data-event-value": "director-radio" },
+      hint: { text: hintText } if onBehalfNameInput,
       conditional: { html: onBehalfNameInput } if onBehalfNameInput
     }) %}
   {% endfor %}

--- a/test/controllers/selectDirector.controller.test.ts
+++ b/test/controllers/selectDirector.controller.test.ts
@@ -44,6 +44,8 @@ describe("SelectDirectorController", () => {
     const DIRECTOR_1_ID = "123"
     const DIRECTOR_2_ID = "456"
     const NOT_A_DIRECTOR_ID = "other"
+    const CORPORATE_DIRECTOR_HINT_TEXT = "You must be authorised by this corporate director to sign the application on its behalf.";
+    const CORPORATE_MEMBER_HINT_TEXT = "You must be authorised by this corporate member to sign the application on its behalf.";
 
     let dissolutionSession: DissolutionSession
 
@@ -179,7 +181,27 @@ describe("SelectDirectorController", () => {
             const htmlAssertHelper: HtmlAssertHelper = new HtmlAssertHelper(res.text)
 
             assert.isTrue(htmlAssertHelper.containsRawText("What is your full name?"))
-            assert.isTrue(htmlAssertHelper.containsRawText("You must be authorised by this corporate director to sign the application on its behalf."))
+            assert.isTrue(htmlAssertHelper.containsText(".govuk-radios__hint", CORPORATE_DIRECTOR_HINT_TEXT))
+        })
+
+        it("should provide a full name input when a corporate member is selected for LLDS01", async () => {
+            dissolutionSession.officerType = OfficerType.MEMBER
+
+            when(session.getDissolutionSession(anything())).thenReturn(dissolutionSession)
+            when(officerService.getActiveDirectorsForCompany(anything(), anything())).thenResolve([
+                aDirectorDetails().withOfficerRole(OfficerRole.CORPORATE_LLP_MEMBER).build()
+            ])
+
+            const app = initApp()
+
+            const res = await request(app)
+                .get(SELECT_DIRECTOR_URI)
+                .expect(StatusCodes.OK)
+
+            const htmlAssertHelper: HtmlAssertHelper = new HtmlAssertHelper(res.text)
+
+            assert.isTrue(htmlAssertHelper.containsRawText("What is your full name?"))
+            assert.isTrue(htmlAssertHelper.containsText(".govuk-radios__hint", CORPORATE_MEMBER_HINT_TEXT))
         })
     })
 


### PR DESCRIPTION
JIRA Ticket ID: [FS-347](https://companieshouse.atlassian.net/browse/FS-347)

## Description

Currently, when a corporate director is selected on the "Which director are you?" page, an authorisation message is show as a hint above the input field.

However, the Gov Design System guidance treats this type of message as instructional content rather than an input hint.

This PR updates the presentation of the authorisation messaging in select director radios to be an instructional hint rather than an input hint.
It also updates the appropriate unit test to check that the instructional content is rendered correctly, and adds a unit test to ensure the changes also apply for LLP's.

## Screenshots

### Before

|Default|Radio Selected|
|--|--|
|![Default - director not selected](https://github.com/user-attachments/assets/e82166fb-1fd9-4a06-a89a-474f77c33d52)|![Selected - director is selected](https://github.com/user-attachments/assets/05c7ef74-71ed-4e59-849f-f694541affff)|

### After (Limited)

|Default|Radio Selected|
|--|--|
|![Default - director not selected](https://github.com/user-attachments/assets/83684fbd-9f0a-419e-84e4-e8bc256454ef)|![Selected - director is selected](https://github.com/user-attachments/assets/06a6afe0-927c-4243-95be-5035dca487e8)|

### After (LLP)

|Default|Radio Selected (before)|Radio Selected (after)|
|--|--|--|
|![Default - member not selected](https://github.com/user-attachments/assets/eb99cf3f-2e56-4c43-8c98-46fdff93a2e5)|![Before - member selected](https://github.com/user-attachments/assets/dee6c563-a721-4d5b-80a9-6e9cd541832c)|![Selected - member is selected](https://github.com/user-attachments/assets/89f33445-040b-4dab-acb6-734bf02f8e56)|

> **Note:** the authorisation message has been updated to refer to *"member"* rather than *"director"* when the entity being dissolved is an LLP

[FS-347]: https://companieshouse.atlassian.net/browse/FS-347?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ