### PR TITLE
fix (FS-353): reorder middleware execution and improve user email middleware error handling

### DIFF
--- a/src/middleware/customServerMiddlewareLoader.middleware.ts
+++ b/src/middleware/customServerMiddlewareLoader.middleware.ts
@@ -18,8 +18,8 @@ export default class CustomServerMiddlewareLoader {
 
     public loadCustomServerMiddleware (app: Application): void {
         app.use(this.sessionMiddleware)
-        app.use(this.saveUserEmailToLocals)
         app.use(this.authMiddleware)
+        app.use(this.saveUserEmailToLocals)
         app.use(this.companyAuthMiddleware)
     }
 }

--- a/src/middleware/saveUserEmailToLocals.middleware.ts
+++ b/src/middleware/saveUserEmailToLocals.middleware.ts
@@ -4,9 +4,15 @@ import SessionService from "app/services/session/session.service"
 
 export default function SaveUserEmailToLocals (sessionService: SessionService): RequestHandler {
     return (req: Request, res: Response, next: NextFunction) => {
-        if (req.session) {
-            res.locals.userEmail = sessionService.getUserEmail(req)
+        try {
+            if (req.session) {
+                res.locals.userEmail = sessionService.getUserEmail(req)
+            }
+            return next()
+        } catch (error: unknown) {
+            // This can happen but the session and auth middlewares should prevent a malformed session
+            const message = error instanceof Error ? error.message : String(error)
+            return next(new Error(`Malformed session: ${message}`))
         }
-        return next()
     }
 }

--- a/test/middleware/customServerMiddlewareLoader.middleware.test.ts
+++ b/test/middleware/customServerMiddlewareLoader.middleware.test.ts
@@ -39,7 +39,7 @@ describe("CustomServerMiddlewareLoader", () => {
         it("should register all middlewares in the correct order", () => {
             loader.loadCustomServerMiddleware(app)
 
-            const registeredMiddlewares = appUseSpy.args.map((call: any[]) => call[0])
+            const registeredMiddlewares = appUseSpy.args.map((call: RequestHandler[]) => call[0])
 
             assert.equal(appUseSpy.callCount, 4)
             assert.deepEqual(registeredMiddlewares, [

--- a/test/middleware/customServerMiddlewareLoader.middleware.test.ts
+++ b/test/middleware/customServerMiddlewareLoader.middleware.test.ts
@@ -1,0 +1,53 @@
+import "reflect-metadata"
+
+import { assert } from "chai"
+import { Application, RequestHandler } from "express"
+import * as sinon from "sinon"
+
+import CustomServerMiddlewareLoader from "app/middleware/customServerMiddlewareLoader.middleware"
+
+describe("CustomServerMiddlewareLoader", () => {
+
+    let loader: CustomServerMiddlewareLoader
+
+    let app: Application
+    let appUseSpy: sinon.SinonSpy
+
+    let sessionMiddleware: RequestHandler
+    let saveUserEmailToLocals: RequestHandler
+    let authMiddleware: RequestHandler
+    let companyAuthMiddleware: RequestHandler
+
+    beforeEach(() => {
+        sessionMiddleware = sinon.stub()
+        saveUserEmailToLocals = sinon.stub()
+        authMiddleware = sinon.stub()
+        companyAuthMiddleware = sinon.stub()
+
+        appUseSpy = sinon.spy()
+        app = { use: appUseSpy } as unknown as Application
+
+        loader = new CustomServerMiddlewareLoader(
+            sessionMiddleware,
+            saveUserEmailToLocals,
+            authMiddleware,
+            companyAuthMiddleware
+        )
+    })
+
+    describe("loadCustomServerMiddleware", () => {
+        it("should register all middlewares in the correct order", () => {
+            loader.loadCustomServerMiddleware(app)
+
+            const registeredMiddlewares = appUseSpy.args.map((call: any[]) => call[0])
+
+            assert.equal(appUseSpy.callCount, 4)
+            assert.deepEqual(registeredMiddlewares, [
+                sessionMiddleware,
+                authMiddleware,
+                saveUserEmailToLocals,
+                companyAuthMiddleware
+            ])
+        })
+    })
+})

--- a/test/middleware/saveUserEmailToLocals.middleware.test.ts
+++ b/test/middleware/saveUserEmailToLocals.middleware.test.ts
@@ -1,0 +1,71 @@
+import "reflect-metadata"
+import { assert } from "chai"
+import { Request, RequestHandler, Response } from "express"
+import * as sinon from "sinon"
+
+import SaveUserEmailToLocals from "app/middleware/saveUserEmailToLocals.middleware"
+import SessionService from "app/services/session/session.service"
+import { ISignInInfo } from "@companieshouse/node-session-handler/lib/session/model/SessionInterfaces"
+import { generateISignInInfo } from "test/fixtures/session.fixtures"
+import { generateRequest } from "test/fixtures/http.fixtures"
+import { SessionKey } from "@companieshouse/node-session-handler/lib/session/keys/SessionKey"
+
+describe("SaveUserEmailToLocals", () => {
+
+    const EMAIL = "some@mail.com"
+
+    let middleware: RequestHandler
+    let sessionService: SessionService
+    let getSessionStub: sinon.SinonStub
+
+    beforeEach(() => {
+        sessionService = new SessionService()
+        getSessionStub = sinon.stub()
+        middleware = SaveUserEmailToLocals(sessionService)
+    })
+
+    it("should retrieve the logged in users email from the request session", () => {
+        const res = { locals: {} } as Response
+        const next = sinon.stub()
+        const signInInfo: ISignInInfo = generateISignInInfo()
+        signInInfo.user_profile!.email = EMAIL
+
+        const req: Request = generateRequest()
+        req.session!.get = getSessionStub.withArgs(SessionKey.SignInInfo).returns(signInInfo)
+
+        middleware(req, res, next)
+
+        assert.isTrue(next.calledOnce)
+        assert.equal(res.locals.userEmail, EMAIL)
+    })
+
+    it("should set email to undefined if there is no sign in info present in the session", () => {
+        const res = { locals: {} } as Response
+        const next = sinon.stub()
+        const signInInfo: ISignInInfo = generateISignInInfo()
+        signInInfo.user_profile!.email = EMAIL
+
+        const req: Request = generateRequest()
+        req.session!.get = getSessionStub.withArgs(SessionKey.SignInInfo).returns(undefined)
+
+        middleware(req, res, next)
+
+        assert.isTrue(next.calledOnce)
+        assert.isUndefined(res.locals.userEmail)
+    })
+
+    it("should set email to undefined if there is no session present in the request", () => {
+        const res = { locals: {} } as Response
+        const next = sinon.stub()
+        const signInInfo: ISignInInfo = generateISignInInfo()
+        signInInfo.user_profile!.email = EMAIL
+
+        const req: Request = generateRequest()
+        req.session = undefined
+
+        middleware(req, res, next)
+
+        assert.isTrue(next.calledOnce)
+        assert.isUndefined(res.locals.userEmail)
+    })
+})

--- a/test/middleware/saveUserEmailToLocals.middleware.test.ts
+++ b/test/middleware/saveUserEmailToLocals.middleware.test.ts
@@ -1,4 +1,5 @@
 import "reflect-metadata"
+
 import { assert } from "chai"
 import { Request, RequestHandler, Response } from "express"
 import * as sinon from "sinon"
@@ -9,6 +10,7 @@ import { ISignInInfo } from "@companieshouse/node-session-handler/lib/session/mo
 import { generateISignInInfo } from "test/fixtures/session.fixtures"
 import { generateRequest } from "test/fixtures/http.fixtures"
 import { SessionKey } from "@companieshouse/node-session-handler/lib/session/keys/SessionKey"
+import { Session } from "@companieshouse/node-session-handler"
 
 describe("SaveUserEmailToLocals", () => {
 
@@ -16,56 +18,56 @@ describe("SaveUserEmailToLocals", () => {
 
     let middleware: RequestHandler
     let sessionService: SessionService
-    let getSessionStub: sinon.SinonStub
+    let req: Request
+    let res: Response
+    let next: sinon.SinonStub
 
     beforeEach(() => {
         sessionService = new SessionService()
-        getSessionStub = sinon.stub()
         middleware = SaveUserEmailToLocals(sessionService)
+        req = generateRequest()
+        res = { locals: {} } as Response
+        next = sinon.stub()
     })
 
     it("should retrieve the logged in users email from the request session", () => {
-        const res = { locals: {} } as Response
-        const next = sinon.stub()
         const signInInfo: ISignInInfo = generateISignInInfo()
         signInInfo.user_profile!.email = EMAIL
-
-        const req: Request = generateRequest()
+        const getSessionStub = sinon.stub()
         req.session!.get = getSessionStub.withArgs(SessionKey.SignInInfo).returns(signInInfo)
 
         middleware(req, res, next)
 
-        assert.isTrue(next.calledOnce)
-        assert.equal(res.locals.userEmail, EMAIL)
+        assert.isTrue(next.calledOnce, "next should be called")
+        assert.equal(res.locals.userEmail, EMAIL, "No userEmail in session")
     })
 
-    it("should set email to undefined if there is no sign in info present in the session", () => {
-        const res = { locals: {} } as Response
-        const next = sinon.stub()
-        const signInInfo: ISignInInfo = generateISignInInfo()
-        signInInfo.user_profile!.email = EMAIL
-
-        const req: Request = generateRequest()
+    it("should set email to undefined when there is no sign in info present in the session", () => {
+        const getSessionStub = sinon.stub()
         req.session!.get = getSessionStub.withArgs(SessionKey.SignInInfo).returns(undefined)
 
         middleware(req, res, next)
 
-        assert.isTrue(next.calledOnce)
+        assert.isTrue(next.calledOnce, "next should be called")
         assert.isUndefined(res.locals.userEmail)
     })
 
-    it("should set email to undefined if there is no session present in the request", () => {
-        const res = { locals: {} } as Response
-        const next = sinon.stub()
-        const signInInfo: ISignInInfo = generateISignInInfo()
-        signInInfo.user_profile!.email = EMAIL
-
-        const req: Request = generateRequest()
+    it("should not set email when there is no session present in the request", () => {
         req.session = undefined
 
         middleware(req, res, next)
 
-        assert.isTrue(next.calledOnce)
+        assert.isTrue(next.calledOnce, "next should be called")
         assert.isUndefined(res.locals.userEmail)
+    })
+
+    it("should not call next if sessionService throws", () => {
+        req.session = {} as Session
+
+        middleware(req, res, next)
+
+        const nextError = next.args[0][0]
+        assert.isTrue(next.calledOnce)
+        assert.equal(nextError.message, "Malformed session: req.session.get is not a function")
     })
 })


### PR DESCRIPTION
JIRA Ticket ID: [FS-353](https://companieshouse.atlassian.net/browse/FS-353)

## Context

> An issue was flagged by an automated scan, specifically in the `SaveUserEmailToLocals` middleware.
It is possible for the `sessionService` to throw instead of letting the auth redirect the user normally.
This creates a session-dependent 500 on unauthenticated or partially initilased sessions.

After some investigation, looking at `node-session-handler` and `web-security-node` (as the session middleware and auth middleware come from those dependencies), it seems that this should not be possible.

### Why

The session middleware sets the session on the request, if an error is thrown when trying to load the session, `req.session` is set to `undefined`.
And if `req.session` is `undefined`, the `getUserEmail` function isn't called in the `SaveUserEmailToLocals` middleware.
The auth middleware will be executed in this scenario and will redirect the user to sign in as it also checks `req.session`.

Even if the session object is malformed and doesn't have a user profile or email, the `SaveUserEmailToLocals` middleware will receive `undefined` for the `userEmail`, as the session service uses _option chaining_ in `getUserEmail`.

There is a way to get a server error, if `getSignInInfo` throws an error.
The only way this could happen is if somehow the session middleware sets the session object but it doesn't have the `get` property on it (`req.session!.get` is potentially dangerous).
However, the session middleware will either set the session to a `Session` object or `undefined`, so this isn't technically possible.

With regards to the two suggested solutions in the ticket, the `SaveUserEmailToLocals` middleware is only needed by the `sign-out-user-banner` component, so it can be safely reordered to trigger after the auth middleware.
Also `getUserEmail` already tolerates missing sign-in data, but the plausible (but impossible?) edge case where an error can be thrown is unhandled. 

## Description

This PR reorders the middleware execution order so that the auth middleware is executed before the `SaveUserEmailToLocals` middleware.
Additionally, the `SaveUserEmailToLocals` has been updated to be more robust by handling any errors from the session service.
I've also added test cases to cover these changes.


[FS-353]: https://companieshouse.atlassian.net/browse/FS-353?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ