### PR TITLE
fix (FS-353): upgrade grpc-js via npm audit to resolve high severity vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1212,9 +1212,9 @@
       }
     },
     "node_modules/@grpc/grpc-js": {
-      "version": "1.14.3",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.3.tgz",
-      "integrity": "sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==",
+      "version": "1.14.4",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.4.tgz",
+      "integrity": "sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/proto-loader": "^0.8.0",


### PR DESCRIPTION
JIRA Ticket ID: [FS-353](https://companieshouse.atlassian.net/browse/FS-353)

## Description

Follow up from https://github.com/companieshouse/dissolution-web/pull/1219, this PR upgrades `grpc-js` via `npm audit fix`.
This high severity vulnerability needed to be resolved as it is blocking the CI build.

Only a patch version upgrade of `@grpc/grpc-js` which is a dependency for `otel`.

[FS-353]: https://companieshouse.atlassian.net/browse/FS-353?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ